### PR TITLE
Fix incorrect test for two plugin functions listening to the same regexp pattern

### DIFF
--- a/tests/unit_tests/local_plugins/hello.py
+++ b/tests/unit_tests/local_plugins/hello.py
@@ -22,10 +22,6 @@ def hello_reply_formatting(message):
 def hello_send(message):
     message.send('hello channel!')
 
-@listen_to('hello$')
-def hello_send_alternative(message):
-    message.send('hello channel!')
-
 @listen_to('hello_decorators')
 @respond_to('hello_decorators')
 def hello_decorators(message):
@@ -56,7 +52,7 @@ def hello_comment(message):
 @listen_to('hello_react', re.IGNORECASE)
 def hello_react(message):
     message.react(':+1:')
-    
+
 @listen_to('picture$', re.IGNORECASE)
 def search_picture(message):
     # check if have file

--- a/tests/unit_tests/local_plugins/hello.py
+++ b/tests/unit_tests/local_plugins/hello.py
@@ -22,6 +22,10 @@ def hello_reply_formatting(message):
 def hello_send(message):
     message.send('hello channel!')
 
+@listen_to('hello$')
+def hello_send_alternative(message):
+    message.send('hello channel!')
+
 @listen_to('hello_decorators')
 @respond_to('hello_decorators')
 def hello_decorators(message):

--- a/tests/unit_tests/test_pluginmanager.py
+++ b/tests/unit_tests/test_pluginmanager.py
@@ -40,8 +40,6 @@ def test_get_plugins():
 			matched_func_names.add(func.__name__)
 	if 'hello_send' not in matched_func_names:
 		raise AssertionError()
-	if 'hello_send_alternative' not in matched_func_names:
-		raise AssertionError()
 	# test: not has_matching_plugin (there is no such plugin `hallo`)
 	reload(sys)
 	matched_func_names = set()
@@ -49,6 +47,4 @@ def test_get_plugins():
 		if func:
 			matched_func_names.add(func.__name__)
 	if 'hello_send' in matched_func_names:
-		raise AssertionError()
-	if 'hello_send_alternative' in matched_func_names:
 		raise AssertionError()

--- a/tests/unit_tests/test_pluginmanager.py
+++ b/tests/unit_tests/test_pluginmanager.py
@@ -34,11 +34,13 @@ def test_get_plugins():
 	manager = PluginsManager(plugins=['single_plugin', 'local_plugins'])
 	manager.init_plugins()
 	matched_func_names = set()
-	# test: has_matching_plugin
+	# test: has_matching_plugin, one plugin function for one regexp pattern only
 	for func, args in manager.get_plugins('listen_to', 'hello'):
 		if func:
 			matched_func_names.add(func.__name__)
-	if 'hello_send' not in matched_func_names:
+	if 'hello_send' in matched_func_names:
+		raise AssertionError('hello_send should be replaced by hello_send_alternative')
+	if 'hello_send_alternative' not in matched_func_names:
 		raise AssertionError()
 	# test: not has_matching_plugin (there is no such plugin `hallo`)
 	reload(sys)


### PR DESCRIPTION
If there are two plugin functions listening to the same regexp pattern, only the latest loaded function will be kept in ``PluginsManager``. Details can be found in ``Bot.listen_to()``. 

``Bot.listen()`` decorator function will keep only one function for one regex pattern.

```python
def listen_to(regexp, flags=0):
    def wrapper(func):
        r = re.compile(regexp, flags | re.DEBUG)
        PluginsManager.commands['listen_to'][r] = func
        logger.info(
            'registered listen_to plugin "%s" to "%s"', func.__name__, regexp)
        return func

    return wrapper
```

So there should not be test for loading two plugin functions listening to the same regexp pattern. It will definitely fail. This is fixed by 42986368bf8d8752c977580f4cdfbfe125e077a1 .

Nevertheless, this test case can be altered to ensure ``Bot.listen()`` keeps only one function for one specific regexp statement. Associated test code was added in  64ccb23add1e760eaa0e6a8c6a5ebfb41f6c738b .
