### PR TITLE
Quick fix to get tests passing with empty PLUGIN settings

### DIFF
--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -62,8 +62,8 @@ class PluginsManager(object):
         if self.plugins == []:
             if hasattr(settings, 'PLUGINS'):
                 self.plugins = settings.PLUGINS
-            else:
-                self.plugins = 'mmpy_bot.plugins'
+            if self.plugins == []:
+                self.plugins.append('mmpy_bot.plugins')
 
         for plugin in self.plugins:
             self._load_plugins(plugin)


### PR DESCRIPTION
@seLain I ran into an issue when running the tests with empty PLUGIN settings for the two bots. Just wanted to run this change by you before merging.