### PR TITLE
Incoming webhook support for APIv4

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ You will need a Mattermost server to run test cases.
  * Create a team, ex. `test-team`, and add `driverbot` and `testbot` into the team
  * Make sure the default public channel `off-topic` exists
  * Create a private channel (ex. `test`) in team `test-team`, and add `driverbot` and `testbot` into the private channel
+ * Give `drivebot` ADMIN previledge on your testing server, and set `pytest_config.DRIVER_ADMIN_PRIVILEGE = True` if you like to test webhooks and other behaviors which requires admin previledge.
 
 Install `PyTest` in development environment.
 

--- a/mmpy_bot/mattermost.py
+++ b/mmpy_bot/mattermost.py
@@ -41,6 +41,14 @@ class MattermostAPI(object):
             verify=self.ssl_verify
         ).text)
 
+    def delete(self, request, data=None):
+        return json.loads(requests.post(
+            self.url + request,
+            headers=self._get_headers(),
+            data=json.dumps(data),
+            verify=self.ssl_verify
+        ).text)
+
     def login(self, name, email, password):
         props = {'name': name, 'login_id': email, 'password': password}
         p = requests.post(
@@ -128,7 +136,11 @@ class MattermostAPI(object):
 
     def hooks_create(self, **kwargs):
         return self.post(
-            '/teams/%s/hooks/incoming/create' % self.default_team_id, kwargs)
+            '/teams/{}/hooks/incoming/create'.format(self.default_team_id), kwargs)
+
+    def hooks_delete(self, webhook_id):
+        return self.delete(
+            '/teams/{}/hooks/incoming/delete'.format(self.default_team_id), {'id': webhook_id})
 
     @staticmethod
     def in_webhook(url, channel, text, username=None, as_user=None,

--- a/mmpy_bot/mattermost_v4.py
+++ b/mmpy_bot/mattermost_v4.py
@@ -100,7 +100,7 @@ class MattermostAPIv4(MattermostAPI):
     def hooks_delete(self, webhook_id):
         response = self.delete('/hooks/incoming/{}'.format(webhook_id))
         if response['status_code'] == 404:
-            raise Exception('API_NOT_FOUND', 'The API /api/v4/hooks/incoming/{hook_id} might bot be supported by your server.')
+            raise Exception('API_NOT_FOUND', 'The API /api/v4/hooks/incoming/{hook_id} might not be supported by your server.')
         return response
 
     @staticmethod

--- a/mmpy_bot/mattermost_v4.py
+++ b/mmpy_bot/mattermost_v4.py
@@ -64,13 +64,19 @@ class MattermostAPIv4(MattermostAPI):
             })
 
     def channel(self, channel_id):
-        channel = {'channel': self.get('/channels/%s' % channel_id)}
+        channel = {'channel': self.get('/channels/{}'.format(channel_id))}
         return channel
+
+    def get_team_by_name(self, team_name):
+        return self.get('/teams/name/{}'.format(team_name))
+
+    def get_channel_by_name(self, channel_name, team_id=None):
+        return self.get('/teams/{}/channels/name/{}'.format(team_id, channel_name))
 
     def get_channels(self, team_id=None):
         if team_id is None:
             team_id = self.default_team_id
-        return self.get('/users/me/teams/%s/channels' % team_id)
+        return self.get('/users/me/teams/{}/channels'.format(team_id))
 
     def create_user_dict(self, v4_dict):
         new_dict = {}
@@ -82,6 +88,41 @@ class MattermostAPIv4(MattermostAPI):
 
     def hooks_list(self):
         return self.get('/hooks/incoming')
+
+    def hooks_create(self, **kwargs):
+        return self.post(
+            '/hooks/incoming', kwargs)
+
+    def hooks_get(self, webhook_id):
+        return self.get(
+            '/hooks/incoming/{}'.format(webhook_id))
+
+    def hooks_delete(self, webhook_id):
+        response = self.delete('/hooks/incoming/{}'.format(webhook_id))
+        if response['status_code'] == 404:
+            raise Exception('API_NOT_FOUND', 'The API /api/v4/hooks/incoming/{hook_id} might bot be supported by your server.')
+        return response
+
+    @staticmethod
+    def in_webhook(url, channel, text, username=None, as_user=None,
+                   parse=None, link_names=None, attachments=None,
+                   unfurl_links=None, unfurl_media=None, icon_url=None,
+                   icon_emoji=None, ssl_verify=True):
+        return requests.post(
+            url, data={
+                'payload': json.dumps({
+                    'channel': channel,
+                    'text': text,
+                    'username': username,
+                    'as_user': as_user,
+                    'parse': parse,
+                    'link_names': link_names,
+                    'attachments': attachments,
+                    'unfurl_links': unfurl_links,
+                    'unfurl_media': unfurl_media,
+                    'icon_url': icon_url,
+                    'icon_emoji': icon_emoji})
+            }, verify=ssl_verify)
     
     def get_file_link(self, file_id):
         return self.get('/files/{}/link'.format(file_id))

--- a/tests/behavior_tests/driver.py
+++ b/tests/behavior_tests/driver.py
@@ -177,9 +177,9 @@ class Driver(object):
 		team = self.bot._client.api.get_team_by_name(
 						team_name=driver_settings.BOT_TEAM)
 		channel = self.bot._client.api.get_channel_by_name(
-						team_id=team['id'], 
+						team_id=team['id'],
 						channel_name=driver_settings.BOT_CHANNEL)
-		response = self.bot._client.api.hooks_create(channel_id=channel['id'], 
+		response = self.bot._client.api.hooks_create(channel_id=channel['id'],
 													 username='pytest_name')
 		if 'status_code' in response:
 			AssertionError('channel creation failed. error response: {}'.format(response))
@@ -221,8 +221,8 @@ class Driver(object):
 
 	def send_post_webhook(self, webhook_id):
 		url = driver_settings.BOT_URL.split('/api')[0]
-		response = self.bot._client.api.in_webhook(url='{}/hooks/{}'.format(url, webhook_id), 
-                               	   				   channel=driver_settings.BOT_CHANNEL, 
+		response = self.bot._client.api.in_webhook(url='{}/hooks/{}'.format(url, webhook_id),
+                               	   				   channel=driver_settings.BOT_CHANNEL,
                                	   				   text='hello',
                                	   			 	   username='pytest_name')
 		if 'status_code' in response and response['status_code'] == 200:

--- a/tests/behavior_tests/pytest_config.py
+++ b/tests/behavior_tests/pytest_config.py
@@ -1,0 +1,5 @@
+# This module keeps configurations for pytest
+
+# Default False. Set to True of the driver bot  is giving 
+# admin privilege in MM server
+DRIVER_ADMIN_PRIVILEGE = False

--- a/tests/behavior_tests/pytest_config.py
+++ b/tests/behavior_tests/pytest_config.py
@@ -1,5 +1,5 @@
 # This module keeps configurations for pytest
 
-# Default False. Set to True of the driver bot  is giving 
+# Default False. Set to True of the driver bot  is giving
 # admin privilege in MM server
 DRIVER_ADMIN_PRIVILEGE = False

--- a/tests/behavior_tests/test_behaviors.py
+++ b/tests/behavior_tests/test_behaviors.py
@@ -41,10 +41,12 @@ def test_bot_direct_message_with_at_prefix(driver):
     driver.wait_for_bot_direct_message('hello sender!')
 
 # [ToDo] Implement this test together with the file upload function
+@pytest.mark.skip(reason="no way of currently testing this")
 def test_bot_upload_file(driver):
     pass
 
 # [ToDo] Needs to find a better way in validating file upload by URL
+@pytest.mark.skip(reason="no way of currently testing this")
 def test_bot_upload_file_from_link(driver):
     #url = 'http://www.mattermost.org/wp-content/uploads/2016/03/logoHorizontal_WS.png'
     #fname = basename(url)

--- a/tests/behavior_tests/test_behaviors.py
+++ b/tests/behavior_tests/test_behaviors.py
@@ -1,6 +1,7 @@
 import subprocess, time
 import pytest
 from driver import Driver
+import pytest_config
 
 def _start_bot_process():
     """
@@ -80,3 +81,18 @@ def test_bot_reply_to_private_channel_message(driver):
     driver.wait_for_bot_private_channel_message('hello sender!')
     driver.send_private_channel_message('hello', colon=False)
     driver.wait_for_bot_private_channel_message('hello sender!')
+
+@pytest.mark.skipif(pytest_config.DRIVER_ADMIN_PRIVILEGE is False,
+                    reason="Needs admin privilege to create webhook.")
+def test_bot_create_get_list_post_delete_webhook(driver):
+    # test create webhook
+    created = driver.create_webhook()
+    # test get webhook
+    driver.get_webhook(created['id'])
+    # test list webhook
+    hooklist = driver.list_webhooks()
+    assert created in hooklist, 'something wrong, the hook {} should be found.'.format(created)
+    # test send post through webhook
+    driver.send_post_webhook(created['id'])
+    # test delete webhook
+    driver.delete_webhook(created['id'])

--- a/tests/behavior_tests/test_behaviors.py
+++ b/tests/behavior_tests/test_behaviors.py
@@ -91,7 +91,8 @@ def test_bot_create_get_list_post_delete_webhook(driver):
     driver.get_webhook(created['id'])
     # test list webhook
     hooklist = driver.list_webhooks()
-    assert created in hooklist, 'something wrong, the hook {} should be found.'.format(created)
+    if created not in hooklist:
+        raise AssertionError('something wrong, the hook {} should be found.'.format(created))
     # test send post through webhook
     driver.send_post_webhook(created['id'])
     # test delete webhook


### PR DESCRIPTION
In `mattermost.MattermostAPI` (APIv3), there were `hooks_list`, `hooks_create`, and `in_webhook` for webhook related behaviors. But they were neither implemented nor tested in `mattermost.MattermostAPIv4`. This PR patched `hooks_get`, `hooks_list`, `hooks_create`, `hooks_delete`, and `in_webhook` for dealing with incoming webhooks in `MattermostAPIv4`.

#### Major changes
+ MattermostAPIv4.hooks_get
+ MattermostAPIv4.hooks_list (updated)
+ MattermostAPIv4.hooks_create
+ MattermostAPIv4.hooks_delete
+ MattermostAPIv4.in_webhook (for post through webhook)
+ other necessary methods and tests

#### Notice 1
There is no webhook behaviors exposed through `bot.Bot` yet because it might be problematic if developer sets API url to `v3`. And it seems meaningless to make it compatible with APIv3 since we are transforming to APIv4. 

So, developer has to access these behaviors like this for now : 
```python
def main():
    bot =Bot()
    created_hook = bot._client.api.hooks_create(channel_id=channel['id'])
    response = bot._client.api.in_webhook(
        url='http://MM_SERVER_DN/hooks/{}'.format(created_hook['id']),
        channel=bot_settings.BOT_CHANNEL,
        text='hello',
        username='mockname')
```
#### Notice 2
Mattermost APIv4 `[GET] /hooks/incoming/{hook_id}` and `[DELETE] /hooks/incoming/{hook_id}` has been merged in Mar. 2017 (mattermost/mattermost-server#5648, mattermost/mattermost-api-reference#124) 

But `[DELETE] /hooks/incoming/{hook_id}` never shows on [APIv4 document](https://api.mattermost.com/#tag/webhooks). I can not find related info on [Mattermost Changelog](https://docs.mattermost.com/administration/changelog.html) either. So... please use `MattermostAPIv4.hooks_delete` with care. Exception will be thrown if this API is not supported on your MM server.
```python
def hooks_delete(self, webhook_id):
    response = self.delete('/hooks/incoming/{}'.format(webhook_id))
    if response['status_code'] == 404:
        raise Exception('API_NOT_FOUND', 'The API /api/v4/hooks/incoming/{hook_id} might bot be supported by your server.')
    return response
```