### PR TITLE
Ensure the bot joined at least one team before success login

### DIFF
--- a/mmpy_bot/mattermost_v4.py
+++ b/mmpy_bot/mattermost_v4.py
@@ -36,6 +36,8 @@ class MattermostAPIv4(MattermostAPI):
 
     def load_initial_data(self):
         self.teams = self.get('/users/me/teams')
+        if len(self.teams) == 0:
+            raise AssertionError('User account of this bot does not join any team yet.')
         self.default_team_id = self.teams[0]['id']
         self.teams_channels_ids = {}
         for team in self.teams:


### PR DESCRIPTION
Resolving issue #9 : Bot logins before joining any team ?

If a bot tries to login before joining any team on MM server, an error will be raised with the message `"User account of this bot does not join any team yet."`