### PR TITLE
fix 'MattermostAPIv4' object has no attribute 'team_id' issue

### DIFF
--- a/mmpy_bot/dispatcher.py
+++ b/mmpy_bot/dispatcher.py
@@ -209,7 +209,7 @@ class Message(object):
         return channel_name
 
     def get_team_id(self):
-        return self._client.api.team_id
+        return self._body['data'].get('team_id', '').strip()
 
     def get_message(self):
         return self._body['data']['post']['message'].strip()


### PR DESCRIPTION
Fixed issue #36
It works for both v3 and v4