### PR TITLE
Fix "similar-code" issue

### DIFF
--- a/mmpy_bot/mattermost.py
+++ b/mmpy_bot/mattermost.py
@@ -119,8 +119,8 @@ class MattermostAPI(object):
             if response.status_code == 200:
                 self.token = response.headers["Token"]
                 self.load_initial_data()
-                self.user = json.loads(response.text)
-                return self.user
+                user = json.loads(response.text)
+                return user
             else:
                 response.raise_for_status()
 

--- a/tests/behavior_tests/test_behaviors.py
+++ b/tests/behavior_tests/test_behaviors.py
@@ -108,5 +108,3 @@ def test_bot_create_get_list_post_delete_webhook(driver):
         raise AssertionError('something wrong, the hook {} should be found.'.format(created))
     # test send post through webhook
     driver.send_post_webhook(created['id'])
-    # test delete webhook
-    driver.delete_webhook(created['id'])


### PR DESCRIPTION
Regarding issue #44 
- extract duplicated login request code as _login() method
- remove webhook delete since it's not officially on APIv4 doc
- some minor fix