### PR TITLE
add filter with users' id for more safe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ If you don't want to expose some bot commands to public, you can add `@allowed_u
 ```python
 @respond_to('^admin$')
 @allow_only_direct_message() #only trigger by direct message, remove this line if you want call this in channel
-@allowed_users('YourNameHere')
+@allowed_users('Your username or email address here')
 def users_access(message):
     pass
 ```

--- a/mmpy_bot/dispatcher.py
+++ b/mmpy_bot/dispatcher.py
@@ -197,7 +197,7 @@ class Message(object):
         return self.get_user_info('id', user_id)
 
     def get_channel_name(self, channel_id=None):
-        channel_id = channel_id or self._body['data']['post']['channel_id']
+        channel_id = channel_id or self.channel
         if channel_id in self.channels:
             channel_name = self.channels[channel_id]
         else:
@@ -223,6 +223,9 @@ class Message(object):
 
     def get_file_link(self, file_id):
         return self._client.api.get_file_link(file_id)
+
+    def upload_file(self, file):
+        return self._client.api.upload_file(file, self.channel)
 
     def _gen_at_message(self, text):
         return '@{}: {}'.format(self.get_username(), text)
@@ -263,22 +266,22 @@ class Message(object):
             attachments=attachments, ssl_verify=self._client.api.ssl_verify,
             **kwargs)
 
-    def reply(self, text):
-        self.send(self._gen_reply(text))
+    def reply(self, text, files=None):
+        self.send(self._gen_reply(text), files=files)
 
-    def send(self, text, channel_id=None):
+    def send(self, text, channel_id=None, files=None):
         return self._client.channel_msg(
-            channel_id or self._body['data']['post']['channel_id'], text)
+            channel_id or self.channel, text, files=files)
 
     def update(self, text, message_id, channel_id=None):
         return self._client.update_msg(
-            message_id, channel_id or self._body['data']['post']['channel_id'],
+            message_id, channel_id or self.channel,
             text
         )
 
     def react(self, emoji_name):
         self._client.channel_msg(
-            self._body['data']['post']['channel_id'], emoji_name,
+            self.channel, emoji_name,
             pid=self._body['data']['post']['id'])
 
     def comment(self, message):

--- a/mmpy_bot/mattermost.py
+++ b/mmpy_bot/mattermost.py
@@ -165,6 +165,18 @@ class MattermostAPI(object):
     def user(self, user_id):
         return self.get_user_info(user_id)
 
+    def upload_file(self, file, channel_id):
+        files = {
+            'files': file,
+            'channel_id': (None, channel_id)
+        }
+        return json.loads(requests.post(
+            self.url + '/files',
+            headers=self._get_headers(),
+            files=files,
+            verify=self.ssl_verify
+        ).text)
+
 
 class MattermostClient(object):
     def __init__(self, url, team, email, password, ssl_verify=True, token=None):
@@ -189,10 +201,10 @@ class MattermostClient(object):
         self.user = self.api.login(team, email, password)
         return self.user
 
-    def channel_msg(self, channel, message, pid=""):
+    def channel_msg(self, channel, message, files=None, pid=""):
         c_id = self.channels.get(channel, {}).get("id") or channel
         return self.api.create_post(self.user["id"],
-                                    c_id, "{}".format(message), pid=pid)
+                                    c_id, "{}".format(message), files, pid)
 
     def update_msg(self, message_id, channel, message, pid=""):
         c_id = self.channels.get(channel, {}).get("id") or channel

--- a/mmpy_bot/utils.py
+++ b/mmpy_bot/utils.py
@@ -56,7 +56,8 @@ def allowed_users(*allowed_users_list):
 
     return plugin
 
-def allowed_userids(*allowed_userids_list):
+
+def allowed_user_ids(*allowed_userids_list):
     def plugin(func):
         def wrapper(message, *args, **kw):
             user = message.get_user_id()

--- a/mmpy_bot/utils.py
+++ b/mmpy_bot/utils.py
@@ -57,11 +57,11 @@ def allowed_users(*allowed_users_list):
     return plugin
 
 
-def allowed_user_ids(*allowed_userids_list):
+def allowed_user_ids(*allowed_user_ids_list):
     def plugin(func):
         def wrapper(message, *args, **kw):
             user = message.get_user_id()
-            if user not in allowed_userids_list:
+            if user not in allowed_user_ids_list:
                 return message.reply("`Permission denied`")
             return func(message, *args, **kw)
 

--- a/mmpy_bot/utils.py
+++ b/mmpy_bot/utils.py
@@ -48,20 +48,8 @@ def allowed_users(*allowed_users_list):
     def plugin(func):
         def wrapper(message, *args, **kw):
             user = message.get_username()
-            if user not in allowed_users_list:
-                return message.reply("`Permission denied`")
-            return func(message, *args, **kw)
-
-        return wrapper
-
-    return plugin
-
-
-def allowed_user_ids(*allowed_user_ids_list):
-    def plugin(func):
-        def wrapper(message, *args, **kw):
-            user = message.get_user_id()
-            if user not in allowed_user_ids_list:
+            user_email = message.get_user_mail()
+            if not {user, user_email} & set(allowed_users_list):
                 return message.reply("`Permission denied`")
             return func(message, *args, **kw)
 

--- a/mmpy_bot/utils.py
+++ b/mmpy_bot/utils.py
@@ -55,3 +55,15 @@ def allowed_users(*allowed_users_list):
         return wrapper
 
     return plugin
+
+def allowed_userids(*allowed_userids_list):
+    def plugin(func):
+        def wrapper(message, *args, **kw):
+            user = message.get_user_id()
+            if user not in allowed_userids_list:
+                return message.reply("`Permission denied`")
+            return func(message, *args, **kw)
+
+        return wrapper
+
+    return plugin

--- a/tests/behavior_tests/run_bot.py
+++ b/tests/behavior_tests/run_bot.py
@@ -2,6 +2,7 @@
 from mmpy_bot.bot import Bot, PluginsManager
 from mmpy_bot.mattermost import MattermostClient
 from mmpy_bot.dispatcher import MessageDispatcher
+from mmpy_bot import settings
 import bot_settings
 
 
@@ -14,6 +15,7 @@ class LocalBot(Bot):
             bot_settings.SSL_VERIFY
         )
         self._plugins = PluginsManager()
+        self._plugins.plugins = bot_settings.PLUGINS
         self._plugins.init_plugins()
         self._dispatcher = MessageDispatcher(self._client, self._plugins)
 

--- a/tests/behavior_tests/run_bot.py
+++ b/tests/behavior_tests/run_bot.py
@@ -2,7 +2,6 @@
 from mmpy_bot.bot import Bot, PluginsManager
 from mmpy_bot.mattermost import MattermostClient
 from mmpy_bot.dispatcher import MessageDispatcher
-from mmpy_bot import settings
 import bot_settings
 
 

--- a/tests/behavior_tests/test_behaviors.py
+++ b/tests/behavior_tests/test_behaviors.py
@@ -108,3 +108,14 @@ def test_bot_create_get_list_post_delete_webhook(driver):
         raise AssertionError('something wrong, the hook {} should be found.'.format(created))
     # test send post through webhook
     driver.send_post_webhook(created['id'])
+
+
+def test_allowed_users(driver):
+    driver.send_channel_message('allowed_driver', tobot=True)
+    driver.wait_for_bot_channel_message('Driver allowed!', tosender=True)
+    driver.send_channel_message('not_allowed_driver', tobot=True)
+    try:
+        driver.wait_for_bot_channel_message('Driver not allowed!', tosender=True)
+        raise AssertionError('response "Hello not allowed!" was not expected.')
+    except AssertionError:
+        pass

--- a/tests/behavior_tests/test_plugins/test_access.py
+++ b/tests/behavior_tests/test_plugins/test_access.py
@@ -1,0 +1,22 @@
+# -*- encoding: utf-8 -*-
+
+from mmpy_bot.utils import allowed_users
+from mmpy_bot.bot import respond_to, listen_to
+
+import sys
+import os
+sys.path.append(os.getcwd()) # enable importing driver_settings
+
+from tests.behavior_tests import driver_settings
+
+
+@respond_to('^allowed_driver$')
+@allowed_users(driver_settings.BOT_NAME)
+def driver_allowed_hello(message):
+    message.reply('Driver allowed!')
+
+
+@respond_to('^not_allowed_driver$')
+@allowed_users('somebody-not-driver')
+def driver_not_allowed_hello(message):
+    message.reply('Driver not allowed!')

--- a/tests/behavior_tests/test_plugins/test_access.py
+++ b/tests/behavior_tests/test_plugins/test_access.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 from mmpy_bot.utils import allowed_users
-from mmpy_bot.bot import respond_to, listen_to
+from mmpy_bot.bot import respond_to
 
 import sys
 import os
@@ -11,7 +11,7 @@ from tests.behavior_tests import driver_settings
 
 
 @respond_to('^allowed_driver$')
-@allowed_users(driver_settings.BOT_NAME)
+@allowed_users(driver_settings.BOT_NAME, driver_settings.BOT_LOGIN)
 def driver_allowed_hello(message):
     message.reply('Driver allowed!')
 

--- a/tests/unit_tests/single_plugin/mock_plugin.py
+++ b/tests/unit_tests/single_plugin/mock_plugin.py
@@ -8,3 +8,14 @@ from tests.behavior_tests.driver_settings import BOT_NAME, BOT_LOGIN
 @allowed_users(BOT_NAME, BOT_LOGIN)
 def mock_users_access(message):
     message.reply('Access allowed!')
+
+
+@respond_to('file$')
+def get_timestamp_file(message):
+    file = open('new.txt', 'w+')
+    result = message.upload_file(file)
+    file.close()
+    if 'file_infos' not in result:
+        message.reply('upload file error')
+    file_id = result['file_infos'][0]['id']
+    message.reply('hello', [file_id])

--- a/tests/unit_tests/single_plugin/mock_plugin.py
+++ b/tests/unit_tests/single_plugin/mock_plugin.py
@@ -1,10 +1,10 @@
 from mmpy_bot.utils import allow_only_direct_message
 from mmpy_bot.utils import allowed_users
 from mmpy_bot.bot import respond_to
-
+from tests.behavior_tests.driver_settings import BOT_NAME, BOT_LOGIN
 
 @respond_to('^admin$')
 @allow_only_direct_message()
-@allowed_users('admin', 'root')
+@allowed_users(BOT_NAME, BOT_LOGIN)
 def mock_users_access(message):
     message.reply('Access allowed!')


### PR DESCRIPTION
I found that the allowed_users function has a flaw: other user can use the unauthorized command by modifying the his username. This situation can be avoided by using user ID filtering. This way is more secure in a multi-user environment.