### PR TITLE
allow users to specify custom websocket origin

### DIFF
--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -26,7 +26,8 @@ class Bot(object):
         self._client = MattermostClient(
             settings.BOT_URL, settings.BOT_TEAM,
             settings.BOT_LOGIN, settings.BOT_PASSWORD,
-            settings.SSL_VERIFY, settings.BOT_TOKEN)
+            settings.SSL_VERIFY, settings.BOT_TOKEN,
+            settings.WS_ORIGIN)
         logger.info('connected to mattermost')
         self._plugins = PluginsManager()
         self._dispatcher = MessageDispatcher(self._client, self._plugins)

--- a/mmpy_bot/mattermost.py
+++ b/mmpy_bot/mattermost.py
@@ -167,7 +167,8 @@ class MattermostAPI(object):
 
 
 class MattermostClient(object):
-    def __init__(self, url, team, email, password, ssl_verify=True, token=None):
+    def __init__(self, url, team, email, password, ssl_verify=True,
+                 token=None, ws_origin=None):
         self.users = {}
         self.channels = {}
         self.mentions = {}
@@ -178,6 +179,7 @@ class MattermostClient(object):
         self.team = team
         self.email = email
         self.password = password
+        self.ws_origin = ws_origin
 
         if token:
             self.user = self.api.me()
@@ -208,6 +210,7 @@ class MattermostClient(object):
     def _connect_websocket(self, url, cookie_name):
         self.websocket = websocket.create_connection(
             url, header=["Cookie: %s=%s" % (cookie_name, self.api.token)],
+            origin=self.ws_origin,
             sslopt={
                 "cert_reqs": ssl.CERT_REQUIRED if self.api.ssl_verify
                 else ssl.CERT_NONE})

--- a/mmpy_bot/settings.py
+++ b/mmpy_bot/settings.py
@@ -17,6 +17,7 @@ BOT_PASSWORD = None
 BOT_TOKEN = None
 BOT_TEAM = 'devops'
 SSL_VERIFY = True
+WS_ORIGIN = None
 
 IGNORE_NOTIFIES = ['@here', '@channel', '@all']
 IGNORE_USERS = []


### PR DESCRIPTION
Allows users to specify an origin header for extra security. See https://security.stackexchange.com/questions/115716/is-the-origin-header-really-useful-for-securing-a-websocket.