### PR TITLE
allow users to specify explicit webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install mmpy_bot
 
 First you need create the mattermost email/password for your bot.
 
-For use all API(V4.0.0), you need add bot user to system admin group to avoid 403 error. 
+For use all API(V4.0.0), you need add bot user to system admin group to avoid 403 error.
 
 ### Configuration
 
@@ -59,6 +59,7 @@ BOT_LOGIN = '<bot-email-address>'
 BOT_PASSWORD = '<bot-password>'
 BOT_TOKEN = None # or '<bot-personal-access-token>' if you have set bot personal access token.
 BOT_TEAM = '<your-team>'  # possible in lowercase
+WEBHOOK_ID = '<bot-webhook-id>' # otherwise the bot will attempt to create one
 ```
 
 Alternatively, you can use the environment variable `MATTERMOST_BOT_URL`,

--- a/mmpy_bot/dispatcher.py
+++ b/mmpy_bot/dispatcher.py
@@ -256,7 +256,10 @@ class Message(object):
         self.send_webapi(self._gen_reply(text), *args, **kwargs)
 
     def send_webapi(self, text, attachments=None, channel_id=None, **kwargs):
-        url = self._get_webhook_url_by_id(self._get_first_webhook())
+        wh = settings.WEBHOOK_ID
+        if not wh:
+            wh = self._get_first_webhook()
+        url = self._get_webhook_url_by_id(wh)
         kwargs['username'] = kwargs.get(
             'username', self.get_username(self._client.user['id']))
         kwargs['icon_url'] = kwargs.get('icon_url', BOT_ICON)

--- a/mmpy_bot/settings.py
+++ b/mmpy_bot/settings.py
@@ -18,7 +18,7 @@ BOT_TOKEN = None
 BOT_TEAM = 'devops'
 SSL_VERIFY = True
 WS_ORIGIN = None
-WEBHOOK_ID = None
+WEBHOOK_ID = None  # if not specified mmpy_bot will attempt to create one
 
 IGNORE_NOTIFIES = ['@here', '@channel', '@all']
 IGNORE_USERS = []

--- a/mmpy_bot/settings.py
+++ b/mmpy_bot/settings.py
@@ -18,6 +18,7 @@ BOT_TOKEN = None
 BOT_TEAM = 'devops'
 SSL_VERIFY = True
 WS_ORIGIN = None
+WEBHOOK_ID = None
 
 IGNORE_NOTIFIES = ['@here', '@channel', '@all']
 IGNORE_USERS = []


### PR DESCRIPTION
Not sure if this is useful to anyone else, but in our mattermost instance we want an explicit webhook instead of requesting them. 