### PR TITLE
Scheduler (#14)

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -126,3 +126,62 @@ File Support
         file_id = result['file_infos'][0]['id']
         # file_id need convert to array
         message.reply('hello', [file_id])
+
+
+Job Scheduling
+--------------
+
+mmpy_bot integrates `schedule 
+<https://github.com/dbader/schedule/>`_ to provide in-process job scheduling.
+
+With `schedule 
+<https://github.com/dbader/schedule/>`_, we can put periodic jobs into waiting queue like this:
+
+.. code-block:: python
+
+    import re
+    from datetime import datetime
+    from mmpy_bot.bot import respond_to
+    from mmpy_bot.scheduler import schedule
+
+
+    @respond_to('reply \"(.*)\" every (.*) seconds', re.IGNORECASE)
+    def reply_every_seconds(message, content, seconds):
+        schedule.every(int(seconds)).seconds.do(message.reply, content)
+
+
+    @respond_to('cancel jobs', re.IGNORECASE)
+    def cancel_jobs(message):
+        schedule.clear()
+        message.reply('all jobs canceled.')
+
+The `schedule 
+<https://github.com/dbader/schedule/>`_ itself provide human-readable APIs to schedule jobs. Check out `schedule.readthedocs.io <https://schedule.readthedocs.io/>`_ for more usage examples.
+
+`schedule 
+<https://github.com/dbader/schedule/>`_ is designed for periodic jobs.
+In order to support one-time-only jobs, mmpy_bot has a monkey-patching on integrated 
+`schedule 
+<https://github.com/dbader/schedule/>`_ package.
+
+We can schedule a one-time-only job by `schedule.once` method.
+You should notice that this method takes a datetime object, which is different from `schedule.every` methods.
+
+The following code example uses `schedule.once` to schedule a job.
+This job will be trigger at `t_time`.
+
+.. code-block:: python
+
+    import re
+    from datetime import datetime
+    from mmpy_bot.bot import respond_to
+    from mmpy_bot.scheduler import schedule
+
+
+    @respond_to('reply \"(.*)\" at (.*)', re.IGNORECASE)
+    def reply_specific_time(message, content, trigger_time):
+        t_time = datetime.strptime(trigger_time, '%b-%d-%Y_%H:%M:%S')
+        schedule.once(t_time).do(message.reply, content)
+
+All jobs added will be triggered periodically. 
+The trigger period (default 5 seconds) can be configured by `JOB_TRIGGER_PERIOD` in settings.py or local_settings.py.

--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -15,6 +15,7 @@ from six.moves import _thread
 from mmpy_bot import settings
 from mmpy_bot.dispatcher import MessageDispatcher
 from mmpy_bot.mattermost import MattermostClient
+from mmpy_bot.scheduler import schedule
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,7 @@ class Bot(object):
         self._plugins.init_plugins()
         self._dispatcher.start()
         _thread.start_new_thread(self._keep_active, tuple())
+        _thread.start_new_thread(self._run_jobs, tuple())
         self._dispatcher.loop()
 
     def _keep_active(self):
@@ -43,6 +45,12 @@ class Bot(object):
         while True:
             time.sleep(60)
             self._client.ping()
+
+    def _run_jobs(self):
+        logger.info('job running thread started')
+        while True:
+            time.sleep(settings.JOB_TRIGGER_PERIOD)
+            schedule.run_pending()
 
 
 class PluginsManager(object):

--- a/mmpy_bot/scheduler.py
+++ b/mmpy_bot/scheduler.py
@@ -1,0 +1,46 @@
+import schedule
+from schedule import default_scheduler
+from datetime import datetime
+
+
+class OneTimeJob(schedule.Job):
+
+    # override schedule.Job._schedule_next_run
+    # to avoid periodic job genration
+    def _schedule_next_run(self):
+        pass
+
+    def set_next_run(self, next_time):
+        if not isinstance(next_time, datetime):
+            raise AssertionError(
+                "The next_time parameter should be a datetime object.")
+        self.at_time = next_time
+        self.next_run = next_time
+
+    def run(self):
+        try: # py3+
+            ret = super().run()
+        except TypeError: # py2.7
+            ret = super(OneTimeJob, self).run()
+        self.scheduler.cancel_job(self)
+        return ret
+
+
+def _default_scheduler__once(self, trigger_time):
+    job = OneTimeJob(0, self)
+    job.set_next_run(trigger_time)
+    return job
+
+
+def _once(trigger_time=datetime.now()):
+    if not isinstance(trigger_time, datetime):
+            raise AssertionError(
+                "The trigger_time parameter should be a datetime object.")
+    return default_scheduler.once(
+            self=default_scheduler,
+            trigger_time=trigger_time)
+
+
+# Monkey-Patching
+default_scheduler.once = _default_scheduler__once
+schedule.once = _once

--- a/mmpy_bot/settings.py
+++ b/mmpy_bot/settings.py
@@ -26,16 +26,24 @@ WORKERS_NUM = 10
 DEFAULT_REPLY_MODULE = None
 DEFAULT_REPLY = None
 
-'''
+"""
 If you use Mattermost Web API to send messages (with send_webapi()
 or reply_webapi()), you can customize the bot logo by providing Icon or Emoji.
 If you use Mattermost API to send messages (with send() or reply()),
 the used icon comes from bot settings and Icon or Emoji has no effect.
-'''
+"""
 # BOT_ICON = 'http://lorempixel.com/64/64/abstract/7/'
 # BOT_EMOJI = ':godmode:'
 
+"""
+Period to trigger jobs in sechduler. Measures in seconds.
+If JOB_TRIGGER_PERIOD is not set, mmpy_bot will set default priod 5 seconds.
+"""
+JOB_TRIGGER_PERIOD = 5
 
+"""
+Load local settings
+"""
 for key in os.environ:
     if key[:15] == 'MATTERMOST_BOT_':
         globals()[key[11:]] = os.environ[key]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ websocket-client==0.35.0
 six==1.10.0
 requests==2.9.1
 Sphinx==1.3.3
+schedule==0.5.0

--- a/tests/behavior_tests/bots/driver.py
+++ b/tests/behavior_tests/bots/driver.py
@@ -134,8 +134,8 @@ class Driver(object):
         else:
             raise AssertionError('expected to get message like "{}", but got nothing'.format(match))
 
-    def wait_for_bot_direct_message(self, match):
-        self._wait_for_bot_message(self.dm_chan, match, tosender=False)
+    def wait_for_bot_direct_message(self, match, maxwait=10):
+        self._wait_for_bot_message(self.dm_chan, match, maxwait=maxwait, tosender=False)
 
     def _wait_for_bot_message(self, channel, match, maxwait=10, tosender=True, thread=False):
         for _ in range(maxwait):
@@ -157,8 +157,8 @@ class Driver(object):
                         return True
             return False
 
-    def wait_for_bot_direct_file(self):
-        self._wait_for_bot_file(self.dm_chan, tosender=False)
+    def wait_for_bot_direct_file(self, maxwait=10):
+        self._wait_for_bot_file(self.dm_chan, tosender=False, maxwait=maxwait)
 
     def _wait_for_bot_file(self, channel, maxwait=10, tosender=True, thread=False):
         for _ in range(maxwait):

--- a/tests/behavior_tests/bots/test_plugins/test_schedule.py
+++ b/tests/behavior_tests/bots/test_plugins/test_schedule.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+
+import re
+from datetime import datetime
+from mmpy_bot.bot import respond_to
+from mmpy_bot.scheduler import schedule
+
+
+@respond_to('reply \"(.*)\" at (.*)', re.IGNORECASE)
+def reply_specific_time(message, content, trigger_time):
+	t_time = datetime.strptime(trigger_time, '%b-%d-%Y_%H:%M:%S')
+	schedule.once(t_time).do(message.reply, content)
+
+
+@respond_to('reply \"(.*)\" every (.*) seconds', re.IGNORECASE)
+def reply_every_seconds(message, content, seconds):
+	schedule.every(int(seconds)).seconds.do(message.reply, content)
+
+
+@respond_to('cancel jobs', re.IGNORECASE)
+def cancel_jobs(message):
+	schedule.clear()
+	message.reply('all jobs canceled.')

--- a/tests/behavior_tests/test_scheduler.py
+++ b/tests/behavior_tests/test_scheduler.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timedelta
+from tests.behavior_tests.fixture import driver
+
+from mmpy_bot import settings
+
+
+def test_bot_reply_specific_time(driver):
+    t_time = datetime.now() + timedelta(seconds=2)
+    str_t_time = t_time.strftime('%b-%d-%Y_%H:%M:%S')
+    driver.send_direct_message(
+        'reply "{0}" at {0}'.format(str_t_time), tobot=True)
+    driver.wait_for_bot_direct_message(
+        str_t_time, maxwait=settings.JOB_TRIGGER_PERIOD+5)
+
+
+def test_bot_reply_every_seconds(driver):
+    driver.send_direct_message('reply "alive" every 6 seconds', tobot=True)
+    driver.wait_for_bot_direct_message(
+        'alive', maxwait=settings.JOB_TRIGGER_PERIOD+5)
+    driver.wait_for_bot_direct_message(
+        'alive', maxwait=settings.JOB_TRIGGER_PERIOD+5)
+    driver.send_direct_message('cancel jobs', tobot=True)
+    driver.wait_for_bot_direct_message(
+        'all jobs canceled.', maxwait=settings.JOB_TRIGGER_PERIOD+5)

--- a/tests/unit_tests/test_scheduler.py
+++ b/tests/unit_tests/test_scheduler.py
@@ -1,0 +1,49 @@
+import pytest
+import time
+from datetime import datetime, timedelta
+from mmpy_bot.scheduler import schedule
+
+
+def foo(msg):
+    print(msg)
+
+
+def foo2(dict_acc):
+    dict_acc['acc'] += 1
+
+
+@pytest.fixture(scope="function")
+def my_schedule():
+    return schedule
+
+
+def test_add_onetime_job_without_trigger_time(my_schedule):
+    my_schedule.once().do(foo, msg='hello')
+    if len(my_schedule.jobs) != 1:
+        raise AssertionError("Job is not added to schedule.")
+    time.sleep(1) # wait for worker threads to start
+    my_schedule.run_pending()
+    if len(my_schedule.jobs) != 0:
+        raise AssertionError("Job is not executed by schedule.")
+
+
+def test_add_onetime_job_with_trigger_time(my_schedule):
+    run_time = datetime.now() + timedelta(seconds=2)
+    my_schedule.once(run_time).do(foo, msg='hello')
+    if len(my_schedule.jobs) != 1:
+        raise AssertionError("Job is not added to schedule.")
+    time.sleep(3) # wait for worker threads to start
+    my_schedule.run_pending()
+    if len(my_schedule.jobs) != 0:
+        raise AssertionError("Job is not executed by schedule.")
+
+
+def test_add_periodic_job(my_schedule):
+    dict_acc = {'acc': 0}
+    my_schedule.every(1).seconds.do(foo2, dict_acc=dict_acc)
+    time.sleep(2) # wait for worker threads to start
+    my_schedule.run_pending()
+    time.sleep(2) # wait for worker threads to start
+    my_schedule.run_pending()
+    if dict_acc['acc'] != 2:
+        raise AssertionError("Incorrect periodic job execution.")


### PR DESCRIPTION
Integrating [schedule](https://github.com/dbader/schedule/) to provide in-process job scheduling.

#### Major changes
* support message reply or job scheduling by specific time or periodically
* doc updated

#### Requirements
Installing schedule package. (already updated in requirements.txt)
```
pip install schedule
```

#### Add periodic jobs
With schedule, we can put periodic jobs into waiting list in plugin handlers like this:
```python
import re
from datetime import datetime
from mmpy_bot.bot import respond_to
from mmpy_bot.scheduler import schedule

@respond_to('reply \"(.*)\" every (.*) seconds', re.IGNORECASE)
def reply_every_seconds(message, content, seconds):
    schedule.every(int(seconds)).seconds.do(message.reply, content)

@respond_to('cancel jobs', re.IGNORECASE)
def cancel_jobs(message):
    schedule.clear()
    message.reply('all jobs canceled.')
```
You can talk to bot `reply "buy birthday gift" every 60 seconds`, and the bot will repeat "buy birthday gift" every 60 seconds until you issue another command `cancel jobs`.

The schedule itself provide human-readable APIs to schedule jobs. Check out [schedule.readthedocs.io](https://schedule.readthedocs.io/en/stable/) for more usage examples.

#### Add onetime job

schedule is designed for periodic jobs. In order to support one-time-only jobs, I made a monkey-patching on integrated schedule package.

We can schedule a one-time-only job by `schedule.once` method. You should notice that this method takes a datetime object, which is different from the `schedule.every` method.

The following handler example uses `schedule.once` to schedule a job. This job will be triggered at t_time.
```python
import re
from datetime import datetime
from mmpy_bot.bot import respond_to
from mmpy_bot.scheduler import schedule

@respond_to('reply \"(.*)\" at (.*)', re.IGNORECASE)
def reply_specific_time(message, content, trigger_time):
    t_time = datetime.strptime(trigger_time, '%b-%d-%Y_%H:%M:%S')
    schedule.once(t_time).do(message.reply, content)
```

#### Settings
All jobs added will be triggered periodically. The trigger period can be configured by `JOB_TRIGGER_PERIOD` in settings.py or local_settings.py. If `JOB_TRIGGER_PERIOD` is not set, the default trigger period will be 5 seconds.

#### Reminder
The schedule package provides only in-process job scheduling, which means if the bot stops, all job will be gone. If you need to keep jobs after bot back to service again, please consider write jobs to a fixture json file and load them back.

I think the most difficult part of job scheduling is how you specify the trigger time, job type, and job content to bot by `natural language-like syntax`. So I left it to you bot developers :stuck_out_tongue_closed_eyes: