### PR TITLE
Ability to pass additional properties to regular messages

### DIFF
--- a/mmpy_bot/dispatcher.py
+++ b/mmpy_bot/dispatcher.py
@@ -266,12 +266,12 @@ class Message(object):
             attachments=attachments, ssl_verify=self._client.api.ssl_verify,
             **kwargs)
 
-    def reply(self, text, files=None):
-        self.send(self._gen_reply(text), files=files)
+    def reply(self, text, files=None, props={}):
+        self.send(self._gen_reply(text), files=files, props=props)
 
-    def send(self, text, channel_id=None, files=None):
+    def send(self, text, channel_id=None, files=None, props={}):
         return self._client.channel_msg(
-            channel_id or self.channel, text, files=files)
+            channel_id or self.channel, text, files=files, props=props)
 
     def update(self, text, message_id, channel_id=None):
         return self._client.update_msg(

--- a/mmpy_bot/mattermost.py
+++ b/mmpy_bot/mattermost.py
@@ -36,7 +36,7 @@ class MattermostAPI(object):
                 'emoji_name': emoji_name,
             })
 
-    def create_post(self, user_id, channel_id, message, files=None, pid=""):
+    def create_post(self, user_id, channel_id, message, files=None, pid="", props={}):
         # create_at = int(time.time() * 1000)
         return self.post(
             '/posts',
@@ -45,6 +45,7 @@ class MattermostAPI(object):
                 'message': message,
                 'file_ids': files or [],
                 'root_id': pid,
+                'props': props
             })
 
     @staticmethod
@@ -218,10 +219,10 @@ class MattermostClient(object):
         return self.api.create_reaction(self.user["id"],
                                         post_id, emoji_name)
 
-    def channel_msg(self, channel, message, files=None, pid=""):
+    def channel_msg(self, channel, message, files=None, pid="", props={}):
         c_id = self.channels.get(channel, {}).get("id") or channel
-        return self.api.create_post(self.user["id"],
-                                    c_id, "{}".format(message), files, pid)
+        return self.api.create_post(self.user["id"], c_id, "{}".format(message),
+                                    files, pid, props=props)
 
     def update_msg(self, message_id, channel, message, pid=""):
         c_id = self.channels.get(channel, {}).get("id") or channel


### PR DESCRIPTION
After this PR you could send messages with attachments (and interactive buttons) without creating incoming hooks:
```python3
props = {
    'attachments': [{
        'fallback': 'Fallback text',
        'author_name': 'Author',
        'author_link': 'http://www.github.com',
        'text': 'Some text here ...',
        'color': '#59afe1',
        'actions': [{
            'name': 'Interactive button',
            'type': 'button',
            'integration': {}
        }]
    }]
}

message.reply('', props=props)
```