### PR TITLE
fix: index out of bound for v= __main__

### DIFF
--- a/mmpy_bot/dispatcher.py
+++ b/mmpy_bot/dispatcher.py
@@ -148,7 +148,7 @@ class MessageDispatcher(object):
         # create dictionary organizing commands by plugin
         modules = {}
         for p, v in iteritems(self._plugins.commands['respond_to']):
-            key = v.__module__.title().split('.')[1]
+            key = v.__module__.title()
             if key not in modules:
                 modules[key] = []
             modules[key].append((p.regex.pattern, v.__doc__))


### PR DESCRIPTION
The original code hides root modules of different plugins. 
So the help message looks like:
```
Bad command "Response to another team.", Here is what I currently know how to do:
Plugin: Test
    reply - None
```
The `Test` plugin module is actually contained in `My_Plugins` module.

But the original code returns "index out of bound" exception when handler functions are put in `__main__` module. This is the case of issue #76 

A straightforward solution is to detect handler functions in `__main__`, and make them special case.
But I think it's OK to present help message like this:
```
Bad command "Response to another team.", Here is what I currently know how to do:
Plugin: Main
    I love you - None
    hi - None
Plugin: My_Plugins.Test
    reply - None
```
Then we can have an easy-fix for issue #76 .

