### PR TITLE
MH - Added expression to explicity match 'ping'

### DIFF
--- a/mmpy_bot/plugins/ping.py
+++ b/mmpy_bot/plugins/ping.py
@@ -5,7 +5,7 @@ import re
 from mmpy_bot.bot import respond_to
 
 
-@respond_to('ping', re.IGNORECASE)
+@respond_to('^ping$', re.IGNORECASE)
 def ping_reply(message):
     message.reply('pong')
 


### PR DESCRIPTION
We have custom plugins that take several arguments i.e @bot [arg1] [arg2] [arg3] [arg4]
One of our use-cases passes 'Bookkeeping' as arg3, the built-in plugin 'ping' is responding to this.

Added pattern matching so that built-in plugin on responds to '^ping$'