### PR TITLE
Adding new decorator allowed_channels

### DIFF
--- a/mmpy_bot/dispatcher.py
+++ b/mmpy_bot/dispatcher.py
@@ -205,6 +205,11 @@ class Message(object):
             channel_name = channel['channel']['name']
             self.channels[channel_id] = channel_name
         return channel_name
+ 
+    def get_channel_display_name(self, channel_id=None):
+        channel_id = channel_id or self.channel
+        channel = self._client.api.channel(channel_id)
+        return channel['channel']['display_name']
 
     def get_team_id(self):
         return self._body['data'].get('team_id', '').strip()

--- a/mmpy_bot/utils.py
+++ b/mmpy_bot/utils.py
@@ -59,3 +59,23 @@ def allowed_users(*allowed_users_list):
         return wrapper
 
     return plugin
+
+
+def allowed_channels(*allowed_channels_list):
+    def plugin(func):
+        @wraps(func)
+        def wrapper(message, *args, **kw):
+            # Check display_name first
+            channel = message.get_channel_display_name()
+            if channel in list(allowed_channels_list):
+                return func(message, *args, **kw)
+            # Check url channel name
+            channel = message.get_channel_name()
+            if channel in list(allowed_channels_list):
+                return func(message, *args, **kw)
+
+            return message.reply("`This plugin only allowed in these channels:{}`".format(list(allowed_channels_list)))
+
+        return wrapper
+
+    return plugin

--- a/tests/behavior_tests/bots/test_plugins/test_access.py
+++ b/tests/behavior_tests/bots/test_plugins/test_access.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 from mmpy_bot.utils import allowed_users
+from mmpy_bot.utils import allowed_channels
 from mmpy_bot.bot import respond_to
 
 import sys
@@ -26,3 +27,15 @@ def driver_not_allowed_hello(message):
 @allowed_users(driver_settings.BOT_LOGIN)
 def driver_allowed_hello_by_email(message):
     message.reply('Driver email allowed!')
+
+
+@respond_to('^allowed_channel$')
+@allowed_channels(driver_settings.BOT_PRIVATE_CHANNEL)
+def driver_allowed_chan(message):
+    message.reply('Driver in channel allowed!')
+
+
+@respond_to('^not_allowed_channel$')
+@allowed_channels(driver_settings.BOT_CHANNEL)
+def driver_not_allowed_chan(message):
+    message.reply('Driver in channel NOT allowed!')

--- a/tests/behavior_tests/test_allowed_channels.py
+++ b/tests/behavior_tests/test_allowed_channels.py
@@ -1,0 +1,13 @@
+from tests.behavior_tests.fixture import driver
+
+
+def test_allowed_channels(driver):
+    print("DEBUG: Testing allowed channels")
+    driver.send_private_channel_message('allowed_channel', tobot=True)
+    driver.wait_for_bot_private_channel_message('Driver in channel allowed!', tosender=True)
+    driver.send_private_channel_message('not_allowed_channel', tobot=True)
+    try:
+        driver.wait_for_bot_private_channel_message('Driver in channel NOT allowed!', tosender=True)
+        raise AssertionError('response "Driver in channel NOT allowed" was not expected.')
+    except AssertionError:
+        pass


### PR DESCRIPTION
As per enhancement request #88 I am adding the ability to limit
bot plugin functions so specific channels. You can use either the
channel display name or the url name.