### PR TITLE
Changing allowed channels functionality to ignore direct messages

### DIFF
--- a/mmpy_bot/utils.py
+++ b/mmpy_bot/utils.py
@@ -68,7 +68,8 @@ def allowed_channels(*allowed_channels_list):
             # Check display_name first
             disp_name = message.get_channel_display_name()
             url_name = message.get_channel_name()
-            if not {disp_name, url_name} & set(allowed_channels_list):
+            is_direct_message = message.is_direct_message()
+            if (not is_direct_message) and (not {disp_name, url_name} & set(allowed_channels_list)):
                 return message.reply(
                     "`This plugin only allowed in these channels:{}`"
                     .format(list(allowed_channels_list)))

--- a/tests/behavior_tests/test_allowed_channels.py
+++ b/tests/behavior_tests/test_allowed_channels.py
@@ -2,9 +2,15 @@ from tests.behavior_tests.fixture import driver  # noqa: F401
 
 
 def test_allowed_channels(driver):  # noqa: F811
+
+    driver.send_direct_message('allowed_channel', tobot=True)
+    driver.wait_for_bot_direct_message(
+        'Driver in channel allowed!')
+
     driver.send_private_channel_message('allowed_channel', tobot=True)
     driver.wait_for_bot_private_channel_message(
         'Driver in channel allowed!', tosender=True)
+
     driver.send_private_channel_message('not_allowed_channel', tobot=True)
     try:
         driver.wait_for_bot_private_channel_message(


### PR DESCRIPTION
As per the request direct messages shoul dnot be checked against the allowed_channels.