### PR TITLE
reply_thread add message in existing thread if present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
 install:
   - pip install -r requirements.txt
   - pip install pytest-cov
+  if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install mock; fi
   - pip install .
 
 before_script:

--- a/mmpy_bot/dispatcher.py
+++ b/mmpy_bot/dispatcher.py
@@ -274,7 +274,8 @@ class Message(object):
 
     def reply_thread(self, text, files=None, props=None):
         self.send(self._gen_reply(text), files=files, props=props or {},
-                  pid=self._body['data']['post']['id'])
+                  pid=(self._body['data']['post']['root_id'] or
+                       self._body['data']['post']['id']))
 
     def comment(self, message):
         self.reply_thread(message)

--- a/tests/unit_tests/test_data/thread_message.json
+++ b/tests/unit_tests/test_data/thread_message.json
@@ -1,0 +1,37 @@
+{
+  "event": "posted",
+  "data": {
+    "channel_display_name": "Off-Topic",
+    "channel_name": "off-topic",
+    "channel_type": "O",
+    "mentions": ["qmw86q7qsjriura9jos75i4why"],
+    "post": {
+      "id": "Ji66o2pX5XmW5XiAsfw5jitrV3",
+      "create_at": 1533085458300,
+      "update_at": 1533085458300,
+      "edit_at": 0,
+      "delete_at": 0,
+      "is_pinned": "False",
+      "user_id": "131gkd5thbdxiq141b3514bgjh",
+      "channel_id": "4fgt3n51f7ftpff91gk1iy1zow",
+      "root_id": "wqpuawcw3iym3pq63s5xi1776r",
+      "parent_id": "",
+      "original_id": "",
+      "message": "hello in thread",
+      "type": "",
+      "props": {},
+      "hashtags": "",
+      "pending_post_id": ""
+    },
+    "sender_name": "betty",
+    "team_id": "au64gza3iint3r31e7ewbrrasw"
+  },
+  "broadcast": {
+    "omit_users": "None",
+    "user_id": "",
+    "channel_id": "4fgt3n51f7ftpff91gk1iy1zow",
+    "team_id": ""
+  },
+  "seq": 29,
+  "message_type": "?"
+}

--- a/tests/unit_tests/test_message.py
+++ b/tests/unit_tests/test_message.py
@@ -1,6 +1,7 @@
 import os
 import json
 import pytest
+from unittest import mock
 from mmpy_bot.dispatcher import Message
 
 
@@ -8,6 +9,14 @@ from mmpy_bot.dispatcher import Message
 def message():
     with open(os.sep.join(
               ['tests', 'unit_tests', 'test_data', 'message.json']),
+              'r') as f:
+        return Message(client=None, body=json.load(f), pool=None)
+
+
+@pytest.fixture(scope="function")
+def thread_message():
+    with open(os.sep.join(
+              ['tests', 'unit_tests', 'test_data', 'thread_message.json']),
               'r') as f:
         return Message(client=None, body=json.load(f), pool=None)
 
@@ -44,3 +53,14 @@ def test_body(message):
         body = json.load(f)
         if message.body != body:
             raise AssertionError()
+
+
+@mock.patch("mmpy_bot.dispatcher.Message.send")
+def test_first_reply_in_thread(mo_send, thread_message):
+    thread_message.reply_thread("third message in thread")
+    mo_send.assert_called_once_with(
+        "@betty: third message in thread",
+        files=None,
+        props={},
+        pid='wqpuawcw3iym3pq63s5xi1776r'
+    )

--- a/tests/unit_tests/test_message.py
+++ b/tests/unit_tests/test_message.py
@@ -1,7 +1,10 @@
 import os
 import json
 import pytest
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    from mock import mock
 from mmpy_bot.dispatcher import Message
 
 


### PR DESCRIPTION

When using reply_thread in existing thread that generate a new thread instead add a message in existing thread. This is an attempt to fix that to reply in existing thread instead !