### PR TITLE
Fix api-call in update_post

### DIFF
--- a/mmpy_bot/mattermost.py
+++ b/mmpy_bot/mattermost.py
@@ -190,9 +190,8 @@ class MattermostAPI(object):
     def update_post(self, message_id, user_id, channel_id,
                     message, files=None, pid=""):
         return self.put(
-            '/posts/%s' % message_id,
+            '/posts/%s/patch' % message_id,
             {
-                'id': message_id,
                 'message': message,
             })
 


### PR DESCRIPTION
According to Mattermost-API-v4 documentation https://api.mattermost.com/#tag/posts%2Fpaths%2F~1posts~1%7Bpost_id%7D~1patch%2Fput the update_post shall be called with sub-path `/patch`.