### PR TITLE
Remove '@' from sender_name

### DIFF
--- a/mmpy_bot/dispatcher.py
+++ b/mmpy_bot/dispatcher.py
@@ -37,7 +37,7 @@ class MessageDispatcher(object):
 
     @staticmethod
     def get_sender(msg):
-        return msg.get('data', {}).get('sender_name', '').strip()
+        return msg.get('data', {}).get('sender_name', '').strip().strip('@')
 
     def ignore(self, _msg):
         return self._ignore_notifies(_msg) or self._ignore_sender(_msg)


### PR DESCRIPTION
In older versions of the API the sender_name didn't include this.
Because it now does this will remove it when it does but still add it
afterwards. This way it doesn't break compatibility with older api
versions and we don't have to verify it.

Signed-off-by: Patrick Guilbert <patrick.pollo.guilbert@gmail.com>