### PR TITLE
Introduce @at_start

### DIFF
--- a/docs/decorators.rst
+++ b/docs/decorators.rst
@@ -30,6 +30,17 @@ Direct messages::
 
 
 
+Actions just after plugin initilization ::
+
+    from mmpy_bot.bot import at_start
+
+
+    @at_start
+    def hello(client):
+        client.connect_websocket()
+        client.ping()
+
+
 Real case
 ---------
 
@@ -61,3 +72,10 @@ So now we can close access to some functions on plugins::
     def sms_to(message, name):
         # some code
         message.reply('Sms was sent to %s' % name)
+
+
+    @at_start
+    def hello(client):
+        team = client.api.get_team_by_name("TESTTEAM")
+        channel = client.api.get_channel_by_name("bot_test", team["id"])
+        client.channel_msg(channel["id"], "Hello, feels good to be alive!!")

--- a/docs/decorators.rst
+++ b/docs/decorators.rst
@@ -4,7 +4,9 @@ Built-in decorators
 ===================
 
 
-Allowed users::
+Allowed users:
+
+.. code-block:: python
 
     from mmpy_bot.utils import allowed_users
     from mmpy_bot.bot import respond_to
@@ -17,7 +19,9 @@ Allowed users::
 
 
 
-Direct messages::
+Direct messages:
+
+.. code-block:: python
 
     from mmpy_bot.utils import allow_only_direct_message
     from mmpy_bot.bot import respond_to
@@ -30,7 +34,9 @@ Direct messages::
 
 
 
-Actions just after plugin initilization ::
+Actions just after plugin initilization:
+
+.. code-block:: python
 
     from mmpy_bot.bot import at_start
 
@@ -45,13 +51,17 @@ Real case
 ---------
 
 For example we have some users on our chat. We want allow some functionality
-to some users. We can create constants with allowed users on bot settings::
+to some users. We can create constants with allowed users on bot settings:
+
+.. code-block:: python
 
     ADMIN_USERS = ['admin', 'root', 'root@admin.com']
     SUPPORT_USERS = ['mike', 'nick', 'nick@nick-server.com']
 
 
-So now we can close access to some functions on plugins::
+So now we can close access to some functions on plugins:
+
+.. code-block:: python
 
     from mmpy_bot.utils import allow_only_direct_message
     from mmpy_bot.utils import allowed_users

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -11,6 +11,7 @@ To write a new plugin, simply create a function decorated by ``mmpy_bot.bot.resp
 
 - A function decorated with ``respond_to`` is called when a message matching the pattern is sent to the bot (direct message or @botname in a channel/group chat)
 - A function decorated with ``listen_to`` is called when a message matching the pattern is sent on a channel/group chat (not directly sent to the bot)
+- A function decorated with ``at_start`` is called as soon as the plugin is initialized (when the bot starts)
 
 .. code-block:: python
 
@@ -38,6 +39,13 @@ To write a new plugin, simply create a function decorated by ``mmpy_bot.bot.resp
         # Message is sent on the channel
         # message.send('I can help everybody!')
 
+    @at_start
+    def hello(client):
+        # Note that contrary to respond_to and listen_to @at_start
+        # receives a client object and not a message object
+        team = client.api.get_team_by_name("TESTTEAM")
+        channel = client.api.get_channel_by_name("bot_test", team["id"])
+        client.channel_msg(channel["id"], "Hello, feels good to be alive!!")
 
 To extract params from the message, you can use regular expression:
 

--- a/mmpy_bot/mattermost.py
+++ b/mmpy_bot/mattermost.py
@@ -81,7 +81,7 @@ class MattermostAPI(object):
         return self.get('/files/{}/link'.format(file_id))
 
     def get_team_by_name(self, team_name):
-            return self.get('/teams/name/{}'.format(team_name))
+        return self.get('/teams/name/{}'.format(team_name))
 
     def get_team_id(self, channel_id):
         for team_id, channels in self.teams_channels_ids.items():
@@ -125,21 +125,21 @@ class MattermostAPI(object):
             }, verify=ssl_verify)
 
     def login(self, team, account, password):
-            props = {'login_id': account, 'password': password}
+        props = {'login_id': account, 'password': password}
+        response = self._login(props)
+        if response.status_code in [301, 302, 307]:
+            # reset self.url to the new URL
+            self.url = response.headers['Location'].replace(
+                    '/users/login', '')
+            # re-try login if redirected
             response = self._login(props)
-            if response.status_code in [301, 302, 307]:
-                # reset self.url to the new URL
-                self.url = response.headers['Location'].replace(
-                        '/users/login', '')
-                # re-try login if redirected
-                response = self._login(props)
-            if response.status_code == 200:
-                self.token = response.headers["Token"]
-                self.load_initial_data()
-                user = json.loads(response.text)
-                return user
-            else:
-                response.raise_for_status()
+        if response.status_code == 200:
+            self.token = response.headers["Token"]
+            self.load_initial_data()
+            user = json.loads(response.text)
+            return user
+        else:
+            response.raise_for_status()
 
     def _login(self, props):
         return requests.post(

--- a/mmpy_bot/scheduler.py
+++ b/mmpy_bot/scheduler.py
@@ -34,8 +34,8 @@ def _default_scheduler__once(self, trigger_time):
 
 def _once(trigger_time=datetime.now()):
     if not isinstance(trigger_time, datetime):
-            raise AssertionError(
-                "The trigger_time parameter should be a datetime object.")
+        raise AssertionError(
+            "The trigger_time parameter should be a datetime object.")
     return default_scheduler.once(
             self=default_scheduler,
             trigger_time=trigger_time)


### PR DESCRIPTION
`@at_start` addresses the use-case from #132.

The interface is rather low level and a little fragile compared to the other decorators.
Currently it grants direct access to the `MattermostClient` object and indirectly `MattermostAPI.
The choice for `client` stems from the need for flexibility when crafting a message. 
From what I gathered, the current code is missing a high level interface that isn't tied to incoming messages, something for another pull request...

I also include a few commits addressing minor code and documentation issues.