### PR TITLE
Fix scheduler.once() trigger_time default value

### DIFF
--- a/mmpy_bot/scheduler.py
+++ b/mmpy_bot/scheduler.py
@@ -32,7 +32,9 @@ def _default_scheduler__once(self, trigger_time):
     return job
 
 
-def _once(trigger_time=datetime.now()):
+def _once(trigger_time=None):
+    if trigger_time is None:
+        trigger_time = datetime.now()
     if not isinstance(trigger_time, datetime):
         raise AssertionError(
             "The trigger_time parameter should be a datetime object.")


### PR DESCRIPTION
The code reads like `trigger_time` should be `now()` but due to the call to `datetime.now()` happening in the function signature the argument is always the time when the `mmpy_bot.scheduler` module was first loaded.
