### PR TITLE
Run tests against a mattermost instance running in docker #129

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,43 @@
-dist: trusty
 sudo: false
 env:
   global:
     - CC_TEST_REPORTER_ID=b0fed3b6b9b09683bf744113f1effa146b532c2fc05f21d0b3f29787807bca01
+    - BOT_URL='http://localhost:8065/api/v4'
+    - DRIVERBOT_LOGIN='driverbot@test.com'
+    - DRIVERBOT_NAME='driverbot'
+    - DRIVERBOT_PASSWORD='driverbot_password'
+    - TESTBOT_LOGIN='testbot@test.com'
+    - TESTBOT_NAME='testbot'
+    - TESTBOT_PASSWORD='testbot_password'
+    - BOT_TEAM='test-team'
+    - DOCKER_CONTAINER_NAME=mattermost
+    - DOCKER_NETWORK=default
+    - BOT_CHANNEL=public
+    - BOT_PRIVATE_CHANNEL=private
 
 branches:
   only:
     - master
 
+services:
+  - docker
+
 language: python
 
 matrix:
   include:
-  - python: "2.7"
-    env: BOT_CHANNEL=PUB_2_7 BOT_PRIVATE_CHANNEL=PRIV_2_7
-  - python: "3.4"
-    env: BOT_CHANNEL=PUB_3_4 BOT_PRIVATE_CHANNEL=PRIV_3_4
-  - python: "3.5"
-    env: BOT_CHANNEL=PUB_3_5 BOT_PRIVATE_CHANNEL=PRIV_3_5
   - python: "3.6"
-    env: BOT_CHANNEL=PUB_3_6 BOT_PRIVATE_CHANNEL=PRIV_3_6
+  - python: "3.7"
+  - python: "3.8"
+  - python: "3.9"
     
 install:
   - pip install -r requirements.txt
   - pip install pytest-cov
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install mock; fi
   - pip install .
 
 before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+  - tests/setup.sh
 
 script: pytest --cov=mmpy_bot tests/ --cov-report xml
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -140,3 +140,22 @@ Using "--cov-report" parameter to write report into "cov_html" folder by html fo
 .. code-block:: bash
 
 	py.test --cov-report html:logs\cov_html --cov=mmpy_bot tests\
+
+Running tests in docker:
+------------------------
+
+If you have docker installed you can spawn a temporary mattermost instance and
+run all the tests by running the following:
+
+.. code-block:: bash
+
+    $ ./tests/run-tests-in-docker.sh
+
+This has predefined environment variables which you can customise.
+Variables in addition to the ones above are:
+
+:code:`DOCKER_CONTAINER_NAME` which specifies the name of the conatiner that runs mattermost
+
+:code:`DOCKER_NETWORK` the docker network to run in, this is created automatically if it doesn't exist
+
+:code:`PYTHON_VERSION` the python version to use

--- a/tests/behavior_tests/bots/driver.py
+++ b/tests/behavior_tests/bots/driver.py
@@ -81,8 +81,11 @@ class Driver(object):
             json_data = self._websocket_safe_read()
             if json_data != '':
                 with self._events_lock:
-                    self.events.extend(
-                        [json.loads(d) for d in json_data.split('\n')])
+                    for d in json_data.split('\n'):
+                        try:
+                            self.events.extend([json.loads(d)])
+                        except:
+                            pass
             time.sleep(1)
 
     def _retrieve_bot_user_ids(self):

--- a/tests/behavior_tests/test_conversation.py
+++ b/tests/behavior_tests/test_conversation.py
@@ -28,8 +28,6 @@ def test_bot_reply_to_channel_message(driver):  # noqa: F811
     driver.wait_for_bot_channel_message('hello sender!')
     driver.send_channel_message('hello', colon=False)
     driver.wait_for_bot_channel_message('hello sender!')
-    driver.send_channel_message('hello', space=False)
-    driver.wait_for_bot_channel_message('hello sender!')
     driver.send_channel_message('hello', colon=False, space=False)
     driver.wait_for_bot_channel_message('hello channel!', tosender=False)
 

--- a/tests/docker-entrypoint.sh
+++ b/tests/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+pip install -r requirements.txt
+pip install pytest-cov
+pip install .
+"$@"

--- a/tests/run-tests-in-docker.sh
+++ b/tests/run-tests-in-docker.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+: ${DRIVERBOT_LOGIN:='driverbot@test.com'}
+: ${DRIVERBOT_NAME:='driverbot'}
+: ${DRIVERBOT_PASSWORD:='driverbot_password'}
+: ${TESTBOT_LOGIN:='testbot@test.com'}
+: ${TESTBOT_NAME:='testbot'}
+: ${TESTBOT_PASSWORD:='testbot_password'}
+: ${BOT_TEAM:='test-team'}
+: ${BOT_CHANNEL:=public}
+: ${BOT_PRIVATE_CHANNEL:=private}
+: ${DOCKER_CONTAINER_NAME:=mmpybot-mattermost}
+: ${BOT_URL:="http://${DOCKER_CONTAINER_NAME}:8065/api/v4"}
+: ${DOCKER_NETWORK:=mmpybot-mattermost}
+: ${PYTHON_VERSION=3.6}
+. ./tests/setup.sh
+docker run -ti --rm \
+--net "$DOCKER_NETWORK" \
+-v "$PWD:/mmpy_bot" \
+-e BOT_URL="$BOT_URL" \
+-e DRIVERBOT_LOGIN="$DRIVERBOT_LOGIN" \
+-e DRIVERBOT_NAME="$DRIVERBOT_NAME" \
+-e DRIVERBOT_PASSWORD="$DRIVERBOT_PASSWORD" \
+-e TESTBOT_LOGIN="$TESTBOT_LOGIN" \
+-e TESTBOT_NAME="$TESTBOT_NAME" \
+-e TESTBOT_PASSWORD="$TESTBOT_PASSWORD" \
+-e BOT_TEAM="$BOT_TEAM" \
+-e BOT_CHANNEL="$BOT_CHANNEL" \
+-e BOT_PRIVATE_CHANNEL="$BOT_PRIVATE_CHANNEL" \
+--entrypoint=/mmpy_bot/tests/docker-entrypoint.sh \
+-w /mmpy_bot \
+python:"$PYTHON_VERSION" \
+pytest

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ue
+curl -sL https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+chmod +x ./cc-test-reporter
+./cc-test-reporter before-build
+docker pull mattermost/mattermost-preview
+docker kill "$DOCKER_CONTAINER_NAME" || true
+docker rm "$DOCKER_CONTAINER_NAME" || true
+docker network create "$DOCKER_NETWORK" || true
+docker run --name "$DOCKER_CONTAINER_NAME" \
+--net "$DOCKER_NETWORK" \
+-d \
+--publish 8065:8065 \
+--add-host dockerhost:127.0.0.1 \
+mattermost/mattermost-preview
+echo -n "Waiting for mattermost to start"
+while ! docker logs "$DOCKER_CONTAINER_NAME"  2>&1 | grep -q "Server is listening"
+do
+    sleep 1
+    echo -n "."
+done
+echo ''
+docker exec "$DOCKER_CONTAINER_NAME" mattermost -c /mm/mattermost/config/config_docker.json user create --email="$DRIVERBOT_LOGIN" --password="$DRIVERBOT_PASSWORD" --username "$DRIVERBOT_NAME"
+docker exec "$DOCKER_CONTAINER_NAME" mattermost -c /mm/mattermost/config/config_docker.json user create --email="$TESTBOT_LOGIN" --password="$TESTBOT_PASSWORD" --username "$TESTBOT_NAME"
+docker exec "$DOCKER_CONTAINER_NAME" mattermost -c /mm/mattermost/config/config_docker.json team create --name "$BOT_TEAM" --display_name "$BOT_TEAM"
+docker exec "$DOCKER_CONTAINER_NAME" mattermost -c /mm/mattermost/config/config_docker.json channel create --team "$BOT_TEAM" --name "$BOT_CHANNEL" --display_name "$BOT_CHANNEL"
+docker exec "$DOCKER_CONTAINER_NAME" mattermost -c /mm/mattermost/config/config_docker.json channel create --team "$BOT_TEAM" --name "$BOT_PRIVATE_CHANNEL" --display_name "$BOT_PRIVATE_CHANNEL" --private
+docker exec "$DOCKER_CONTAINER_NAME" mattermost -c /mm/mattermost/config/config_docker.json team add "$BOT_TEAM" "$TESTBOT_NAME" "$DRIVERBOT_NAME"
+docker exec "$DOCKER_CONTAINER_NAME" mattermost -c /mm/mattermost/config/config_docker.json channel add  "$BOT_TEAM:$BOT_CHANNEL" "$TESTBOT_NAME" "$DRIVERBOT_NAME"
+docker exec "$DOCKER_CONTAINER_NAME" mattermost -c /mm/mattermost/config/config_docker.json channel add  "$BOT_TEAM:$BOT_PRIVATE_CHANNEL" "$TESTBOT_NAME" "$DRIVERBOT_NAME"


### PR DESCRIPTION
* Run tests in using a docker mattermost container in travis
* Added script tests/run-tests-in-docker.sh to run tests in docker locally
* Removed testing on EOL python versions
* Fixed tests/behavior_tests/test_conversation.py test where mattermost
  no longer highlights a user if there is no space after the @username
* Fixed tests throwing an error when invalid JSON is returned from the
  websocket
* Added docs for running tests in docker locally

Closes #136