### PR TITLE
Provide docker files to easily run the bot locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.8-slim-buster
+WORKDIR /app
+COPY requirements.txt requirements.txt
+COPY dev-requirements.txt dev-requirements.txt
+RUN pip install -r requirements.txt -r dev-requirements.txt
+COPY . .
+RUN pip install -e .[dev]
+ENTRYPOINT python entrypoint.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.7"
+
+services:
+  app:
+    container_name: "mmpy_bot"
+    build: .
+    network_mode: host
+    extra_hosts:
+      - "dockerhost:127.0.0.1"
+    environment:
+      - MATTERMOST_URL="http://127.0.0.1"
+      - BOT_TOKEN="e691u15hajdebcnqpfdceqihcc"
+      - MATTERMOST_PORT=8065
+      - SSL_VERIFY=False
+      - WEBHOOK_HOST_ENABLED=True
+      - WEBHOOK_HOST_URL="http://127.0.0.1"
+      - WEBHOOK_HOST_PORT=8579

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,10 @@ services:
     extra_hosts:
       - "dockerhost:127.0.0.1"
     environment:
-      - MATTERMOST_URL="http://127.0.0.1"
-      - BOT_TOKEN="e691u15hajdebcnqpfdceqihcc"
+      - MATTERMOST_URL=http://127.0.0.1
+      - BOT_TOKEN=e691u15hajdebcnqpfdceqihcc
       - MATTERMOST_PORT=8065
       - SSL_VERIFY=False
       - WEBHOOK_HOST_ENABLED=True
-      - WEBHOOK_HOST_URL="http://127.0.0.1"
+      - WEBHOOK_HOST_URL=http://127.0.0.1
       - WEBHOOK_HOST_PORT=8579

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,7 +1,9 @@
 from mmpy_bot import Bot, ExamplePlugin, Settings, WebHookExample
 
 bot = Bot(
-    settings=Settings(),  # Either specify your settings here or as environment variables.
+    # Either specify your settings here or use environment variables to override them.
+    # See docker-compose.yml for an example you can use for local development.
+    settings=Settings(),
     plugins=[ExamplePlugin(), WebHookExample()],  # Add your own plugins here.
 )
 bot.run()

--- a/mmpy_bot/settings.py
+++ b/mmpy_bot/settings.py
@@ -69,7 +69,7 @@ class Settings:
                 )
             # Use get_args to find out what kind of sequence it is.
             value = _get_comma_separated_list(value, type=get_args(f.type)[0])
-        elif f.type in [int, float, str]:  # type: ignore
+        elif f.type in [int, float, str, bool]:  # type: ignore
             value = f.type(value)
         else:
             raise TypeError(


### PR DESCRIPTION
Following the description in #156. I have chosen not to use the docker image in CI, since we run tests both on Python 3.8 and 3.9 and building a docker image for both (or using the image for only one of them) unnecessarily complicates things. Technically the CI is already run inside a docker image anyway, the only difference is that this one is explicitly available for public use.

I have not published this image to the docker registry yet, but will do so when we actually release `2.0.0`. To prevent merge conflicts, I have not yet updated the documentation here. Let's merge this first and then update the documentation in #161.