### PR TITLE
Avoid implicit globals

### DIFF
--- a/mmpy_bot/driver.py
+++ b/mmpy_bot/driver.py
@@ -40,7 +40,7 @@ class Driver(mattermostdriver.Driver):
         self,
         channel_id: str,
         message: str,
-        file_paths: Sequence[str] = [],
+        file_paths: Optional[Sequence[str]] = None,
         root_id: str = "",
         props: Dict = {},
         ephemeral_user_id: Optional[str] = None,
@@ -51,6 +51,9 @@ class Driver(mattermostdriver.Driver):
         paths are specified, those files will be uploaded to mattermost first and then
         attached.
         """
+        if file_paths is None:
+            file_paths = []
+
         file_ids = (
             self.upload_files(file_paths, channel_id) if len(file_paths) > 0 else []
         )
@@ -110,7 +113,7 @@ class Driver(mattermostdriver.Driver):
         self,
         message: Message,
         response: str,
-        file_paths: Sequence[str] = [],
+        file_paths: Optional[Sequence[str]] = None,
         props: Dict = {},
         ephemeral: bool = False,
     ):
@@ -119,6 +122,9 @@ class Driver(mattermostdriver.Driver):
         Supports sending ephemeral messages if the bot permissions allow it. If the
         message is part of a thread, the reply will be added to that thread.
         """
+        if file_paths is None:
+            file_paths = []
+
         if ephemeral:
             return self.create_post(
                 channel_id=message.channel_id,

--- a/mmpy_bot/function.py
+++ b/mmpy_bot/function.py
@@ -58,7 +58,7 @@ class MessageFunction(Function):
         *args,
         direct_only: bool = False,
         needs_mention: bool = False,
-        allowed_users: Sequence[str] = [],
+        allowed_users: Optional[Sequence[str]] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -66,7 +66,11 @@ class MessageFunction(Function):
         self.is_click_function = isinstance(self.function, click.Command)
         self.direct_only = direct_only
         self.needs_mention = needs_mention
-        self.allowed_users = [user.lower() for user in allowed_users]
+
+        if allowed_users is None:
+            self.allowed_users = []
+        else:
+            self.allowed_users = [user.lower() for user in allowed_users]
 
         if self.is_click_function:
             _function = self.function.callback
@@ -166,10 +170,13 @@ def listen_to(
     *,
     direct_only=False,
     needs_mention=False,
-    allowed_users=[],
+    allowed_users=None,
 ):
     """Wrap the given function in a MessageFunction class so we can register some
     properties."""
+
+    if allowed_users is None:
+        allowed_users = []
 
     def wrapped_func(func):
         reg = regexp


### PR DESCRIPTION
This PR refactors a couple default arguments to initialize in the function scope instead of as globals.