### PR TITLE
Fixed mutual default arguments in bot's `__init__`

### DIFF
--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -20,8 +20,10 @@ class Bot:
     def __init__(
         self,
         settings: Optional[Settings] = None,
-        plugins: Sequence[Plugin] = [ExamplePlugin(), WebHookExample()],
+        plugins: Optional[Sequence[Plugin]] = None,
     ):
+        if plugins is None:
+            plugins = [ExamplePlugin(), WebHookExample()]
         # Use default settings if none were specified.
         self.settings = settings or Settings()
         logging.basicConfig(


### PR DESCRIPTION
Although it's unlikely that `Bot` instance will be created more than
1 time, but basically it's not a good pattern to leave mutual object
as default function's arguments, since refenrences of them are left
the same each time per function call.

https://stackoverflow.com/questions/41686829/warning-about-mutable-default-argument-in-pycharm
https://florimond.dev/blog/articles/2018/08/python-mutable-defaults-are-the-source-of-all-evil/#:~:text=In%20Python%2C%20when%20passing%20a,or%20even%20a%20class%20instance.