### PR TITLE
Add bot shutdown mechanism on driver.disconnect()

### DIFF
--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -88,8 +88,12 @@ class Bot:
             self.event_handler.start()
 
         except KeyboardInterrupt as e:
-            self.stop()
             raise e
+
+        finally:
+            # When either the event handler finishes (if we asked it to stop) or we
+            # receive a KeyboardInterrupt, shut down the bot.
+            self.stop()
 
     def stop(self):
         logging.info("Stopping bot.")

--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -53,6 +53,8 @@ class Bot:
         if self.settings.WEBHOOK_HOST_ENABLED:
             self._initialize_webhook_server()
 
+        self.running = False
+
     def _initialize_plugins(self, plugins: Sequence[Plugin]):
         for plugin in plugins:
             plugin.initialize(self.driver, self.settings)
@@ -72,6 +74,8 @@ class Bot:
     def run(self):
         logging.info(f"Starting bot {self.__class__.__name__}.")
         try:
+            self.running = True
+
             self.driver.threadpool.start()
             # Start a thread to run potential scheduled jobs
             self.driver.threadpool.start_scheduler_thread(
@@ -96,9 +100,13 @@ class Bot:
             self.stop()
 
     def stop(self):
+        if not self.running:
+            return
+
         logging.info("Stopping bot.")
         # Shutdown the running plugins
         for plugin in self.plugins:
             plugin.on_stop()
         # Stop the threadpool
         self.driver.threadpool.stop()
+        self.running = False

--- a/mmpy_bot/webhook_server.py
+++ b/mmpy_bot/webhook_server.py
@@ -63,7 +63,7 @@ class WebHookServer:
         asyncio.get_event_loop().create_task(self._obtain_responses_loop())
 
     async def stop(self):
-        self.app_runner.cleanup()
+        await self.app_runner.cleanup()
         self.running = False
 
     async def _obtain_responses_loop(self):

--- a/tests/unit_tests/bot_test.py
+++ b/tests/unit_tests/bot_test.py
@@ -36,16 +36,16 @@ class TestBot:
         for plugin in plugins:
             assert plugin.initialize.called_once_with(bot.driver)
 
-    @mock.patch("mmpy_bot.driver.Driver.init_websocket")
     @mock.patch.multiple("mmpy_bot.Plugin", on_start=mock.DEFAULT, on_stop=mock.DEFAULT)
-    def test_run(self, init_websocket, bot, **mocks):
-        bot.run()
-        init_websocket.assert_called_once()
+    def test_run(self, bot, **mocks):
+        with mock.patch.object(bot.driver, "init_websocket") as init_websocket:
+            bot.run()
+            init_websocket.assert_called_once()
 
-        for plugin in bot.plugins:
-            plugin.on_start.assert_called_once()
+            for plugin in bot.plugins:
+                plugin.on_start.assert_called_once()
 
-        bot.stop()
+            bot.stop()
 
-        for plugin in bot.plugins:
-            plugin.on_stop.assert_called_once()
+            for plugin in bot.plugins:
+                plugin.on_stop.assert_called_once()


### PR DESCRIPTION
Closes #164. You can just call `driver.disconnect()` to stop the event loop, which will subsequently call `stop()` on the bot itself. ~~Depends on https://github.com/Vaelor/python-mattermost-driver/pull/80.~~