### PR TITLE
Don't remove trailing spaces from Markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,8 +7,10 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-trim_trailing_whitespace = true
 max_line_length = 79
+
+[*.md]
+trim_trailing_whitespace = false
 
 [*.{py,json,rst,ini,js,go,lua,sql}]
 indent_style = space


### PR DESCRIPTION
Trailing space in markdown is meaningful so we shouldn't remove it