### PR TITLE
Add driver options to deal with websocket fixes

### DIFF
--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -42,7 +42,7 @@ class Bot:
                 "scheme": self.settings.SCHEME,
                 "verify": self.settings.SSL_VERIFY,
                 "keepalive": True,
-                "connect_kw_args": {'ping_interval': None},
+                "connect_kw_args": {"ping_interval": None},
             }
         )
         self.driver.login()

--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -41,6 +41,8 @@ class Bot:
                 "token": self.settings.BOT_TOKEN,
                 "scheme": self.settings.SCHEME,
                 "verify": self.settings.SSL_VERIFY,
+                "keepalive": True,
+                "connect_kw_args": {'ping_interval': None}               
             }
         )
         self.driver.login()

--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -42,7 +42,7 @@ class Bot:
                 "scheme": self.settings.SCHEME,
                 "verify": self.settings.SSL_VERIFY,
                 "keepalive": True,
-                "connect_kw_args": {'ping_interval': None}               
+                "connect_kw_args": {'ping_interval': None},
             }
         )
         self.driver.login()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.7.4.post0
 click>=7.0
-mattermostdriver>=7.1.0
+mattermostdriver>=7.3.0
 schedule>=0.6.0
 Sphinx>=1.3.3


### PR DESCRIPTION
This should be merged once the mm driver has the [websocket reconnect PR](https://github.com/Vaelor/python-mattermost-driver/pull/86) merged and released.

- [x]  We need to also update requirements.txt to use the newest fixed driver.