### PR TITLE
Upgrade mattermostdriver to 7.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.7.4.post0
 click>=7.0
-mattermostdriver>=7.1.0
+mattermostdriver>=7.2.0
 schedule>=0.6.0
 Sphinx>=1.3.3


### PR DESCRIPTION
Required for #175, since `7.2.0` introduces `driver.disconnect()`.