### PR TITLE
Loosen up aiohttp requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.7.4.post0
+aiohttp>=3.7.4.post0
 click>=7.0
 mattermostdriver>=7.1.0
 schedule>=0.6.0


### PR DESCRIPTION
Pinning a dependency to a specific version is very annoying if you need a different version of that dependency downstream. I think we can assume that whatever we're currently doing will also work in future versions of `aiohttp`, and if not we can either pin it once a problem occurs, or just upgrade and modify the code.