### PR TITLE
add allowed_channels

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -116,6 +116,17 @@ Restrict messages to specific users
             """Will only trigger if the username of the sender is 'admin' or 'root'."""
             self.driver.reply_to(message, "Access allowed!")
 
+
+Restrict messages to specific channels
+----------------------------------
+
+    .. code-block:: python
+
+        @listen_to("^poke$", allowed_channels=["#staff", "#town-square"])
+        async def poke(self, message: Message):
+            """Will only trigger if the message has been send in '#staff' or '#town-square'."""
+            self.driver.reply_to(message, "Access allowed!")
+
 Click support
 -------------
     `mmpy_bot` now supports `click <https://click.palletsprojects.com/en/7.x/>`_ commands, so you can build a robust CLI-like experience if you need it.


### PR DESCRIPTION
As i need this for my personal instance, i decided to try and implement a filter for channels.
The reason is that i dont want the bot to work in every channel.

I just took the allowed_users filter and adapted it to channels, i didnt test it yet.

TODO:

* [x] Documentation
* [x] Testing