### PR TITLE
Fix pre-commit framework inconsistencies with GA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     rev: 21.5b1
     hooks:
       - id: black
+        exclude: (.*/)*snapshots/
   - repo: https://gitlab.com/pycqa/flake8
     # Checks the code for PEP8 violations and common pitfals
     rev: 3.9.0
@@ -34,16 +35,18 @@ repos:
     rev: '2020.10.8'
     hooks:
       - id: pytype
+        # Don't run pytype in an isolated venv or it will fail on imports
+        language: system
         args:
           - "-j"
           - "auto"
-          - "."
   - repo: https://github.com/myint/docformatter
     # Formats docstrings following PEP 257
-    rev: v1.3.1
+    rev: v1.4
     hooks:
       - id: docformatter
         args:
+          - "--in-place"
           - "--wrap-summaries"
           - "88"
           - "--wrap-descriptions"

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -129,7 +129,7 @@ Restrict messages to specific users
 
 
 Restrict messages to specific channels
-----------------------------------
+--------------------------------------
 
     .. code-block:: python
 
@@ -141,11 +141,15 @@ Restrict messages to specific channels
 Click support
 -------------
 
-`mmpy_bot` now supports `click <https://click.palletsprojects.com/en/7.x/>`_ commands, so you can build a robust CLI-like experience if you need it.
-The example below registers a `hello_click` command that takes a positional argument, a keyword argument and a toggleable flag, which are automatically converted to the correct type.
-For example, it can be called with `hello_click my_argument --keyword-arg=3 -f` and will parse the arguments accordingly.
-A nice benefit of `click` commands is that they also automatically generate nicely formatted help strings.
-Try sending "help" to the `ExamplePlugin` to see what it looks like!
+`mmpy_bot` now supports `click <https://click.palletsprojects.com/en/7.x/>`_
+commands, so you can build a robust CLI-like experience if you need it. The
+example below registers a `hello_click` command that takes a positional
+argument, a keyword argument and a toggleable flag, which are automatically
+converted to the correct type. For example, it can be called with
+`hello_click my_argument --keyword-arg=3 -f` and will parse the arguments
+accordingly. A nice benefit of `click` commands is that they also
+automatically generate nicely formatted help strings. Try sending "help" to
+the `ExamplePlugin` to see what it looks like!
 
 .. code-block:: python
 


### PR DESCRIPTION
Lints a few cases that were missed before and configures exceptions.

- `black` was still trying to lint .py files in unittest snapshots
  - `.mypy` and other files/folders don't need to be excluded since pre-commit only looks at files tracked by git.
- `pytest` was failing to find modules - pre-commit defaults to running in an independent `venv`. Using `system` disables that behavior and inherits the environment.
- `docformatter` use newer version and do `--in-place` changes.
  - `docformatter` is still a little annoying to use. When running locally it automatically fixes things and git tells us what changes but in a GitHub Action the output only tells which file failed not what caused it.