### PR TITLE
Fix scheduler.once() running multiple times

### DIFF
--- a/mmpy_bot/scheduler.py
+++ b/mmpy_bot/scheduler.py
@@ -18,8 +18,20 @@ class OneTimeJob(schedule.Job):
             raise AssertionError("The next_time parameter should be a datetime object.")
         self.at_time = next_time
         self.next_run = next_time
+        self.should_run = True
+
+    @property
+    def should_run(self):
+        return self._keep_running and super().should_run
+
+    @should_run.setter
+    def should_run(self, value):
+        self._keep_running = value
 
     def run(self):
+        # This prevents the job from running more than once
+        self.should_run = False
+
         super().run()
         return schedule.CancelJob()
 

--- a/tests/unit_tests/scheduler_test.py
+++ b/tests/unit_tests/scheduler_test.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Dict
+from unittest.mock import Mock
 
 import pytest
 
@@ -29,6 +30,19 @@ def test_once():
         file.seek(0)
         # Verify that the written time was within 0.3 seconds of the expected time
         assert float(file.readline()) - 2 == pytest.approx(start, abs=0.3)
+
+
+def test_once_single_call():
+    mock = Mock()
+    mock.side_effect = lambda: time.sleep(0.2)
+
+    schedule.once().do(mock)
+
+    for _ in range(10):
+        schedule.run_pending()
+        time.sleep(0.05)
+
+    mock.assert_called_once()
 
 
 def test_recurring_thread():


### PR DESCRIPTION
The included test executes the function 4 times.
The fix overrides [should_run](https://github.com/dbader/schedule/blob/6eb0b5346b1ce35ece5050e65789fa6e44368175/schedule/__init__.py#L637) preventing the job from [being picked up](https://github.com/dbader/schedule/blob/6eb0b5346b1ce35ece5050e65789fa6e44368175/schedule/__init__.py#L98) again.

The job will not be retried if it fails to execute.