### PR TITLE
Provide shortcuts for direct messages

### DIFF
--- a/mmpy_bot/driver.py
+++ b/mmpy_bot/driver.py
@@ -57,29 +57,24 @@ class Driver(mattermostdriver.Driver):
         file_ids = (
             self.upload_files(file_paths, channel_id) if len(file_paths) > 0 else []
         )
+
+        post = dict(
+            channel_id=channel_id,
+            message=message,
+            file_ids=file_ids,
+            root_id=root_id,
+            props=props,
+        )
+
         if ephemeral_user_id:
             return self.posts.create_ephemeral_post(
                 {
                     "user_id": ephemeral_user_id,
-                    "post": {
-                        "channel_id": channel_id,
-                        "message": message,
-                        "file_ids": file_ids,
-                        "root_id": root_id,
-                        "props": props,
-                    },
+                    "post": post,
                 }
             )
 
-        return self.posts.create_post(
-            {
-                "channel_id": channel_id,
-                "message": message,
-                "file_ids": file_ids,
-                "root_id": root_id,
-                "props": props,
-            }
-        )
+        return self.posts.create_post(post)
 
     def get_thread(self, post_id: str):
         """Wrapper around driver.posts.get_thread, which for some reason returns

--- a/mmpy_bot/driver.py
+++ b/mmpy_bot/driver.py
@@ -111,31 +111,64 @@ class Driver(mattermostdriver.Driver):
         file_paths: Optional[Sequence[str]] = None,
         props: Dict = {},
         ephemeral: bool = False,
+        direct: bool = False,
     ):
         """Reply to the given message.
 
         Supports sending ephemeral messages if the bot permissions allow it. If the
         message is part of a thread, the reply will be added to that thread.
+
+        Also supports replying privately by setting direct=True.
         """
         if file_paths is None:
             file_paths = []
 
-        if ephemeral:
-            return self.create_post(
-                channel_id=message.channel_id,
+        if direct and not message.is_direct_message:
+            # NOTE we explicitly don't pass root_id as it would refer to a
+            # post in a channel not a private session
+            direct_args = dict(
+                receiver_id=message.user_id,
                 message=response,
-                root_id=message.reply_id,
                 file_paths=file_paths,
                 props=props,
-                ephemeral_user_id=message.user_id,
+                ephemeral_user_id=message.user_id if ephemeral else None,
             )
 
-        return self.create_post(
+            return self.direct_message(**direct_args)
+
+        reply_args = dict(
             channel_id=message.channel_id,
             message=response,
             root_id=message.reply_id,
             file_paths=file_paths,
             props=props,
+            ephemeral_user_id=message.user_id if ephemeral else None,
+        )
+
+        return self.create_post(**reply_args)
+
+    def direct_message(
+        self,
+        receiver_id: str,
+        message: str,
+        file_paths: Optional[Sequence[str]] = None,
+        root_id: str = "",
+        props: Dict = {},
+        ephemeral_user_id: Optional[str] = None,
+    ):
+        # Private/direct messages are sent to a special channel that
+        # includes the bot and the recipient
+        direct_id = self.channels.create_direct_message_channel(
+            [self.user_id, receiver_id]
+        )["id"]
+
+        return self.create_post(
+            channel_id=direct_id,
+            message=message,
+            root_id=root_id,
+            file_paths=file_paths,
+            props=props,
+            ephemeral_user_id=ephemeral_user_id,
         )
 
     def respond_to_web(self, event: WebHookEvent, response):


### PR DESCRIPTION
Adds:

1. A `direct_message()` driver shortcut to be used when the bot needs to initiate a new private/direct message.
2. A `direct=` argument to `reply_to()` to allow replying to a user request in a private/direct message.