### PR TITLE
Allow disabling default logging handlers

### DIFF
--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -29,20 +29,11 @@ class Bot:
             plugins = [ExamplePlugin(), WebHookExample()]
         # Use default settings if none were specified.
         self.settings = settings or Settings()
+
         if enable_logging:
-            logging.basicConfig(
-                **{
-                    "format": self.settings.LOG_FORMAT,
-                    "datefmt": "%m/%d/%Y %H:%M:%S",
-                    "level": logging.DEBUG if self.settings.DEBUG else logging.INFO,
-                    "filename": self.settings.LOG_FILE,
-                    "filemode": "w",
-                }
-            )
-            # define and add a Handler which writes log messages to the sys.stdout
-            self.console = logging.StreamHandler(stream=sys.stdout)
-            self.console.setFormatter(logging.Formatter(self.settings.LOG_FORMAT))
-            logging.getLogger("").addHandler(self.console)
+            self._register_logger()
+        else:
+            self.console = None
 
         self.driver = Driver(
             {
@@ -66,6 +57,21 @@ class Bot:
             self._initialize_webhook_server()
 
         self.running = False
+
+    def _register_logger(self):
+        logging.basicConfig(
+            **{
+                "format": self.settings.LOG_FORMAT,
+                "datefmt": "%m/%d/%Y %H:%M:%S",
+                "level": logging.DEBUG if self.settings.DEBUG else logging.INFO,
+                "filename": self.settings.LOG_FILE,
+                "filemode": "w",
+            }
+        )
+        # define and add a Handler which writes log messages to the sys.stdout
+        self.console = logging.StreamHandler(stream=sys.stdout)
+        self.console.setFormatter(logging.Formatter(self.settings.LOG_FORMAT))
+        logging.getLogger("").addHandler(self.console)
 
     def _initialize_plugins(self, plugins: Sequence[Plugin]):
         for plugin in plugins:

--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -23,24 +23,26 @@ class Bot:
         self,
         settings: Optional[Settings] = None,
         plugins: Optional[Sequence[Plugin]] = None,
+        enable_logging: bool = True,
     ):
         if plugins is None:
             plugins = [ExamplePlugin(), WebHookExample()]
         # Use default settings if none were specified.
         self.settings = settings or Settings()
-        logging.basicConfig(
-            **{
-                "format": self.settings.LOG_FORMAT,
-                "datefmt": "%m/%d/%Y %H:%M:%S",
-                "level": logging.DEBUG if self.settings.DEBUG else logging.INFO,
-                "filename": self.settings.LOG_FILE,
-                "filemode": "w",
-            }
-        )
-        # define and add a Handler which writes log messages to the sys.stdout
-        self.console = logging.StreamHandler(stream=sys.stdout)
-        self.console.setFormatter(logging.Formatter(self.settings.LOG_FORMAT))
-        logging.getLogger("").addHandler(self.console)
+        if enable_logging:
+            logging.basicConfig(
+                **{
+                    "format": self.settings.LOG_FORMAT,
+                    "datefmt": "%m/%d/%Y %H:%M:%S",
+                    "level": logging.DEBUG if self.settings.DEBUG else logging.INFO,
+                    "filename": self.settings.LOG_FILE,
+                    "filemode": "w",
+                }
+            )
+            # define and add a Handler which writes log messages to the sys.stdout
+            self.console = logging.StreamHandler(stream=sys.stdout)
+            self.console.setFormatter(logging.Formatter(self.settings.LOG_FORMAT))
+            logging.getLogger("").addHandler(self.console)
 
         self.driver = Driver(
             {


### PR DESCRIPTION
mmpy_bot doesn't check if logging listeners or handlers already exist before registering new ones. This PR makes it optional.
Defaults to enabled logging for backwards compatibility.

The motivation for this change is to allow the user to configure their own logging settings. As-is, they will most likely end up with duplicated logging messages.