### PR TITLE
Improve representation of scheduled one-time-jobs

### DIFF
--- a/mmpy_bot/scheduler.py
+++ b/mmpy_bot/scheduler.py
@@ -12,6 +12,12 @@ class OneTimeJob(schedule.Job):
     def _schedule_next_run(self):
         pass
 
+    def __repr__(self):
+        txt = super().__repr__()
+        # One time jobs always read "Every 0 None at ..."
+        # due undefined self.interval (0) and self.unit (None)
+        return txt.replace("Every 0 None", "Once")
+
     def set_next_run(self, next_time: datetime):
         if not isinstance(next_time, datetime):
             raise AssertionError("The next_time parameter should be a datetime object.")

--- a/tests/unit_tests/scheduler_test.py
+++ b/tests/unit_tests/scheduler_test.py
@@ -39,6 +39,8 @@ def test_once_single_call():
 
     schedule.once().do(mock)
 
+    assert repr(schedule.jobs[0]).startswith("Once at")
+
     for _ in range(10):
         schedule.run_pending()
         time.sleep(0.05)


### PR DESCRIPTION
Before:
```
Every 0 None at 2021-09-01 17:08:43.262977 do check_user() (last run: [never], next run: 2021-09-01 17:08:43)
```
After:
```
Once at 2021-09-01 17:08:43.262977 do check_user() (last run: [never], next run: 2021-09-01 17:08:43)
```