### PR TITLE
Avoid crashing threadpool threads on exception

### DIFF
--- a/mmpy_bot/threadpool.py
+++ b/mmpy_bot/threadpool.py
@@ -60,7 +60,10 @@ class ThreadPool(object):
             function, arguments = self._queue.get()
             # Notify the pool that we started working
             self._busy_workers.put(1)
-            function(*arguments)
+            try:
+                function(*arguments)
+            except Exception:
+                log.exception()
             # Notify the pool that we finished working
             self._queue.task_done()
             self._busy_workers.get()


### PR DESCRIPTION
A crashed scheduler thread would prevent any future scheduled jobs to run