### PR TITLE
Bump mattermostdriver to 7.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.7.4.post0
 click>=7.0
-mattermostdriver>=7.3.0
+mattermostdriver>=7.3.2
 schedule>=0.6.0
 Sphinx>=1.3.3


### PR DESCRIPTION
Bumping upstream package `mattermostdriver` to 7.3.2 to resolve #283.