### PR TITLE
Changed re.match to re.search() in _handle_post() and _handle_webhook()

### DIFF
--- a/mmpy_bot/event_handler.py
+++ b/mmpy_bot/event_handler.py
@@ -88,7 +88,7 @@ class EventHandler(object):
         # the rest.
         tasks = []
         for matcher, functions in self.message_listeners.items():
-            match = matcher.match(message.text)
+            match = matcher.search(message.text)
             if match:
                 groups = list([group for group in match.groups() if group != ""])
                 for function in functions:
@@ -108,7 +108,7 @@ class EventHandler(object):
         # handle the rest.
         tasks = []
         for matcher, functions in self.webhook_listeners.items():
-            match = matcher.match(event.webhook_id)
+            match = matcher.search(event.webhook_id)
             if match:
                 for function in functions:
                     # Create an asyncio task to handle this callback


### PR DESCRIPTION
This allows the bot to match text not at the start of a post, described in issue #289. 