### PR TITLE
Fix log.exception missing one argument

### DIFF
--- a/mmpy_bot/threadpool.py
+++ b/mmpy_bot/threadpool.py
@@ -63,7 +63,7 @@ class ThreadPool(object):
             try:
                 function(*arguments)
             except Exception:
-                log.exception()
+                log.exception("Unhandled exception in main loop")
             # Notify the pool that we finished working
             self._queue.task_done()
             self._busy_workers.get()


### PR DESCRIPTION
This avoids crashing when an exception is already being handled.
`log.exception()` needs one argument, a message to go along with the exception.

Apologies as this went by unnoticed for quite some time.