### PR TITLE
No reply if permission denied

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,5 @@ flake8==4.0.1
 isort==5.10.1
 pytest==7.1.2
 pytest-xdist==2.5.0
-pytype==2021.10.18
+pytype==2022.4.15
 snapshottest==0.6.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,5 @@ flake8==4.0.1
 isort==5.10.1
 pytest==7.1.2
 pytest-xdist==2.5.0
-pytype==2022.4.15
+pytype==2021.10.18
 snapshottest==0.6.0

--- a/mmpy_bot/function.py
+++ b/mmpy_bot/function.py
@@ -168,7 +168,7 @@ class MessageFunction(Function):
                 self.direct_only,
                 self.allowed_users,
                 self.allowed_channels,
-                self.no_reply
+                self.no_reply,
             ]
         ):
             # Print some information describing the usage settings.

--- a/mmpy_bot/function.py
+++ b/mmpy_bot/function.py
@@ -129,6 +129,10 @@ class MessageFunction(Function):
             return return_value
 
         if self.allowed_users and message.sender_name not in self.allowed_users:
+            if self.no_reply is False:
+                self.plugin.driver.reply_to(
+                    message, "You do not have permission to perform this action!"
+                )
             return return_value
 
         if self.allowed_channels and message.channel_name not in self.allowed_channels:

--- a/mmpy_bot/function.py
+++ b/mmpy_bot/function.py
@@ -124,9 +124,6 @@ class MessageFunction(Function):
             return return_value
 
         if self.allowed_users and message.sender_name not in self.allowed_users:
-            self.plugin.driver.reply_to(
-                message, "You do not have permission to perform this action!"
-            )
             return return_value
 
         if self.allowed_channels and message.channel_name not in self.allowed_channels:

--- a/mmpy_bot/function.py
+++ b/mmpy_bot/function.py
@@ -132,7 +132,7 @@ class MessageFunction(Function):
             return return_value
 
         if self.allowed_channels and message.channel_name not in self.allowed_channels:
-            if self.no_reply:
+            if self.no_reply is False:
                 self.plugin.driver.reply_to(
                     message, "You do not have permission to perform this action!"
                 )

--- a/mmpy_bot/function.py
+++ b/mmpy_bot/function.py
@@ -63,7 +63,7 @@ class MessageFunction(Function):
         *args,
         direct_only: bool = False,
         needs_mention: bool = False,
-        no_reply: bool = False,
+        silence_fail_msg: bool = False,
         allowed_users: Optional[Sequence[str]] = None,
         allowed_channels: Optional[Sequence[str]] = None,
         **kwargs,
@@ -73,7 +73,7 @@ class MessageFunction(Function):
         self.is_click_function = isinstance(self.function, click.Command)
         self.direct_only = direct_only
         self.needs_mention = needs_mention
-        self.no_reply = no_reply
+        self.silence_fail_msg = silence_fail_msg
 
         if allowed_users is None:
             self.allowed_users = []
@@ -129,14 +129,14 @@ class MessageFunction(Function):
             return return_value
 
         if self.allowed_users and message.sender_name not in self.allowed_users:
-            if self.no_reply is False:
+            if self.silence_fail_msg is False:
                 self.plugin.driver.reply_to(
                     message, "You do not have permission to perform this action!"
                 )
             return return_value
 
         if self.allowed_channels and message.channel_name not in self.allowed_channels:
-            if self.no_reply is False:
+            if self.silence_fail_msg is False:
                 self.plugin.driver.reply_to(
                     message, "You do not have permission to perform this action!"
                 )
@@ -168,7 +168,7 @@ class MessageFunction(Function):
                 self.direct_only,
                 self.allowed_users,
                 self.allowed_channels,
-                self.no_reply,
+                self.silence_fail_msg,
             ]
         ):
             # Print some information describing the usage settings.
@@ -187,7 +187,7 @@ class MessageFunction(Function):
             if self.allowed_channels:
                 string += f"{spaces(4)}- Restricted to certain channels.\n"
 
-            if self.no_reply:
+            if self.silence_fail_msg:
                 string += f"{spaces(4)}- If it should reply to a non privileged user / in a non privileged channel.\n"
 
         return string
@@ -201,7 +201,7 @@ def listen_to(
     needs_mention=False,
     allowed_users=None,
     allowed_channels=None,
-    no_reply=False,
+    silence_fail_msg=False,
     **metadata,
 ):
     """Wrap the given function in a MessageFunction class so we can register some
@@ -236,7 +236,7 @@ def listen_to(
             needs_mention=needs_mention,
             allowed_users=allowed_users,
             allowed_channels=allowed_channels,
-            no_reply=no_reply,
+            silence_fail_msg=silence_fail_msg,
             **metadata,
         )
 

--- a/mmpy_bot/function.py
+++ b/mmpy_bot/function.py
@@ -63,6 +63,7 @@ class MessageFunction(Function):
         *args,
         direct_only: bool = False,
         needs_mention: bool = False,
+        no_reply: bool = False,
         allowed_users: Optional[Sequence[str]] = None,
         allowed_channels: Optional[Sequence[str]] = None,
         **kwargs,
@@ -72,6 +73,7 @@ class MessageFunction(Function):
         self.is_click_function = isinstance(self.function, click.Command)
         self.direct_only = direct_only
         self.needs_mention = needs_mention
+        self.no_reply = no_reply
 
         if allowed_users is None:
             self.allowed_users = []
@@ -130,9 +132,10 @@ class MessageFunction(Function):
             return return_value
 
         if self.allowed_channels and message.channel_name not in self.allowed_channels:
-            self.plugin.driver.reply_to(
-                message, "You do not have permission to perform this action!"
-            )
+            if self.no_reply:
+                self.plugin.driver.reply_to(
+                    message, "You do not have permission to perform this action!"
+                )
             return return_value
 
         if self.is_click_function:
@@ -161,6 +164,7 @@ class MessageFunction(Function):
                 self.direct_only,
                 self.allowed_users,
                 self.allowed_channels,
+                self.no_reply
             ]
         ):
             # Print some information describing the usage settings.
@@ -179,6 +183,9 @@ class MessageFunction(Function):
             if self.allowed_channels:
                 string += f"{spaces(4)}- Restricted to certain channels.\n"
 
+            if self.no_reply:
+                string += f"{spaces(4)}- If it should reply to a non privileged user / in a non privileged channel.\n"
+
         return string
 
 
@@ -190,6 +197,7 @@ def listen_to(
     needs_mention=False,
     allowed_users=None,
     allowed_channels=None,
+    no_reply=False,
     **metadata,
 ):
     """Wrap the given function in a MessageFunction class so we can register some
@@ -224,6 +232,7 @@ def listen_to(
             needs_mention=needs_mention,
             allowed_users=allowed_users,
             allowed_channels=allowed_channels,
+            no_reply=no_reply,
             **metadata,
         )
 

--- a/mmpy_bot/plugins/example.py
+++ b/mmpy_bot/plugins/example.py
@@ -19,6 +19,11 @@ class ExamplePlugin(Plugin):
         """Showcases a function with restricted access."""
         self.driver.reply_to(message, "Access allowed!")
 
+    @listen_to("^offtopic_channel$", allowed_channels=["off-topic"])
+    async def channels_access(self, message: Message):
+        """Showcases a function which can only be used in specific channels"""
+        self.driver.reply_to(message, "Access allowed!")
+
     @listen_to("^busy|jobs$", re.IGNORECASE, needs_mention=True)
     async def busy_reply(self, message: Message):
         """Show the number of busy worker threads."""

--- a/mmpy_bot/plugins/example.py
+++ b/mmpy_bot/plugins/example.py
@@ -21,7 +21,7 @@ class ExamplePlugin(Plugin):
 
     @listen_to("^offtopic_channel$", allowed_channels=["off-topic"])
     async def channels_access(self, message: Message):
-        """Showcases a function which can only be used in specific channels"""
+        """Showcases a function which can only be used in specific channels."""
         self.driver.reply_to(message, "Access allowed!")
 
     @listen_to("^busy|jobs$", re.IGNORECASE, needs_mention=True)

--- a/tests/integration_tests/docker-compose.yml
+++ b/tests/integration_tests/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: "mattermost-bot-test"
     build: .
     command: ./mm/docker-entry.sh
-    network_mode: host
+    ports:
+      - 8065:8065
     extra_hosts:
       - "dockerhost:127.0.0.1"

--- a/tests/unit_tests/event_handler_test.py
+++ b/tests/unit_tests/event_handler_test.py
@@ -13,13 +13,14 @@ def create_message(
     mentions=["qmw86q7qsjriura9jos75i4why"],
     channel_type="O",
     sender_name="betty",
+    channel_name="off-topic",
 ):
     return Message(
         {
             "event": "posted",
             "data": {
                 "channel_display_name": "Off-Topic",
-                "channel_name": "off-topic",
+                "channel_name": channel_name,
                 "channel_type": channel_type,
                 "mentions": mentions,
                 "post": {

--- a/tests/unit_tests/function_test.py
+++ b/tests/unit_tests/function_test.py
@@ -223,7 +223,9 @@ class TestMessageFunction:
 
         driver.reply_to = mock.Mock(wraps=fake_reply)
 
-        f = listen_to("", allowed_channels=["off-topic"], silence_fail_msg=True)(wrapped)
+        f = listen_to("", allowed_channels=["off-topic"], silence_fail_msg=True)(
+            wrapped
+        )
         f.plugin = ExamplePlugin().initialize(driver)
 
         # This is fine, the names are not caps sensitive

--- a/tests/unit_tests/function_test.py
+++ b/tests/unit_tests/function_test.py
@@ -212,7 +212,7 @@ class TestMessageFunction:
         wrapped.assert_not_called()
         driver.reply_to.assert_called_once()
 
-    def test_allowed_channels_no_reply(self):
+    def test_allowed_channels_silence_fail_msg(self):
         wrapped = mock.create_autospec(example_listener)
         wrapped.__qualname__ = "wrapped"
         # Create a driver with a mocked reply function
@@ -223,7 +223,7 @@ class TestMessageFunction:
 
         driver.reply_to = mock.Mock(wraps=fake_reply)
 
-        f = listen_to("", allowed_channels=["off-topic"], no_reply=True)(wrapped)
+        f = listen_to("", allowed_channels=["off-topic"], silence_fail_msg=True)(wrapped)
         f.plugin = ExamplePlugin().initialize(driver)
 
         # This is fine, the names are not caps sensitive

--- a/tests/unit_tests/function_test.py
+++ b/tests/unit_tests/function_test.py
@@ -188,6 +188,29 @@ class TestMessageFunction:
         wrapped.assert_not_called()
         driver.reply_to.assert_called_once()
 
+    def test_allowed_channels(self):
+        wrapped = mock.create_autospec(example_listener)
+        wrapped.__qualname__ = "wrapped"
+        # Create a driver with a mocked reply function
+        driver = Driver()
+
+        def fake_reply(message, text):
+            assert "you do not have permission" in text.lower()
+
+        driver.reply_to = mock.Mock(wraps=fake_reply)
+
+        f = listen_to("", allowed_channels=["off-topic"])(wrapped)
+        f.plugin = ExamplePlugin().initialize(driver)
+
+        # This is fine, the names are not caps sensitive
+        f(create_message(channel_name="off-topic"))
+        wrapped.assert_called_once()
+        wrapped.reset_mock()
+
+        # This is not fine, and we expect the fake reply to be called.
+        f(create_message(channel_name="town-square"))
+        wrapped.assert_not_called()
+        driver.reply_to.assert_called_once()
 
 def example_webhook_listener(self, event):
     # Used to copy the arg specs to mock.Mock functions.

--- a/tests/unit_tests/function_test.py
+++ b/tests/unit_tests/function_test.py
@@ -212,6 +212,31 @@ class TestMessageFunction:
         wrapped.assert_not_called()
         driver.reply_to.assert_called_once()
 
+    def test_allowed_channels_no_reply(self):
+        wrapped = mock.create_autospec(example_listener)
+        wrapped.__qualname__ = "wrapped"
+        # Create a driver with a mocked reply function
+        driver = Driver()
+
+        def fake_reply(message, text):
+            assert "you do not have permission" in text.lower()
+
+        driver.reply_to = mock.Mock(wraps=fake_reply)
+
+        f = listen_to("", allowed_channels=["off-topic"], no_reply=True)(wrapped)
+        f.plugin = ExamplePlugin().initialize(driver)
+
+        # This is fine, the names are not caps sensitive
+        f(create_message(channel_name="off-topic"))
+        wrapped.assert_called_once()
+        wrapped.reset_mock()
+
+        # This is not fine, and we expect the fake reply not to be called.
+        f(create_message(channel_name="town-square"))
+        wrapped.assert_not_called()
+        driver.reply_to.assert_not_called()
+
+
 def example_webhook_listener(self, event):
     # Used to copy the arg specs to mock.Mock functions.
     pass


### PR DESCRIPTION
Hi!

This is a little "feature" ive made for myself because the "permission denied" message annoyed me in channels where certain commands were not allowed (For example, i dont want the "cats" command to throw a "permission denied" in "#salespitches" when someone accidentally types "cats")

This PR contains:
- a "silence_fail_msg" parameter that allows to silence the "permission denied" reply (Default is to reply with "permission denied")
- Unit tests for the allowed_channels feature and the "silence_fail_msg" parameter
- Instead of using host networking in the podman-compose file, i opted for port exposing, as host networking does not seem to work correctly. [1]
- ~~A bump for pytype, as the version mentioned in the requirements does not exist anymore?~~
  - My version of python was too new for the version of pytype, thats why it did not "exist". Ive reverted the commit that bumped pytype.

[1]
```
podman create --name=mattermost-bot-test --label io.podman.compose.config-hash=123 --label io.podman.compose.project=integration_tests --label io.podman.compose.version=0.0.1 --label com.docker.compose.project=integration_tests --label com.docker.compose.project.working_dir=/home/selen/github/mmpy_bot/tests/integration_tests --label com.docker.compose.project.config_files=tests/integration_tests/docker-compose.yml --label com.docker.compose.container-number=1 --label com.docker.compose.service=app --network host --net integration_tests_default --network-alias app --add-host dockerhost:127.0.0.1 integration_tests_app ./mm/docker-entry.sh
Error: cannot set multiple networks without bridge network mode, selected mode host: invalid argument
exit code: 125
```