### PR TITLE
Update core to use mattermostautodriver instead of mattermostdriver

### DIFF
--- a/mmpy_bot/driver.py
+++ b/mmpy_bot/driver.py
@@ -1,4 +1,5 @@
 import queue
+import warnings
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Union
 
@@ -77,9 +78,13 @@ class Driver(mattermostdriver.Driver):
         return self.posts.create_post(post)
 
     def get_thread(self, post_id: str):
-        """Wrapper around driver.posts.get_thread, which for some reason returns
+        warnings.warn("get_thread is deprecated. Use get_post_thread instead", DeprecationWarning)
+        return self.get_post_thread(post_id)
+
+    def get_post_thread(self, post_id: str):
+        """Wrapper around driver.posts.get_post_thread, which for some reason returns
         duplicate and wrongly ordered entries in the ordered list."""
-        thread_info = self.posts.get_thread(post_id)
+        thread_info = self.posts.get_post_thread(post_id)
 
         id_stamps = []
         for id, post in thread_info["posts"].items():

--- a/mmpy_bot/driver.py
+++ b/mmpy_bot/driver.py
@@ -67,7 +67,7 @@ class Driver(mattermostdriver.Driver):
         )
 
         if ephemeral_user_id:
-            return self.posts.create_ephemeral_post(
+            return self.posts.create_post_ephemeral(
                 {
                     "user_id": ephemeral_user_id,
                     "post": post,

--- a/mmpy_bot/driver.py
+++ b/mmpy_bot/driver.py
@@ -158,7 +158,7 @@ class Driver(mattermostdriver.Driver):
     ):
         # Private/direct messages are sent to a special channel that
         # includes the bot and the recipient
-        direct_id = self.channels.create_direct_message_channel(
+        direct_id = self.channels.create_direct_channel(
             [self.user_id, receiver_id]
         )["id"]
 

--- a/mmpy_bot/driver.py
+++ b/mmpy_bot/driver.py
@@ -199,10 +199,22 @@ class Driver(mattermostautodriver.Driver):
     ) -> List[str]:
         """Given a list of file paths and the channel id, uploads the corresponding
         files and returns a list their internal file IDs."""
-        file_dict = {}
+        file_list = []
         for path in file_paths:
             path = Path(path)
-            file_dict[path.name] = Path(path).read_bytes()
+            # Note: 'files' should be a name of an expected attribute in the body
+            # but seems to be ignored when simply uploading files to mattermost
+            file_list.append(
+                (
+                    "files",
+                    (
+                        path.name,
+                        Path(path).read_bytes(),
+                    ),
+                )
+            )
 
-        result = self.files.upload_file(channel_id, file_dict)
+        result = self.files.upload_file(
+            files=file_list, data={"channel_id": channel_id}
+        )
         return list(info["id"] for info in result["file_infos"])

--- a/mmpy_bot/driver.py
+++ b/mmpy_bot/driver.py
@@ -3,7 +3,7 @@ import warnings
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Union
 
-import mattermostdriver
+import mattermostautodriver
 from aiohttp.client import ClientSession
 
 from mmpy_bot.threadpool import ThreadPool
@@ -11,12 +11,12 @@ from mmpy_bot.webhook_server import WebHookServer
 from mmpy_bot.wrappers import Message, WebHookEvent
 
 
-class Driver(mattermostdriver.Driver):
+class Driver(mattermostautodriver.Driver):
     user_id: str = ""
     username: str = ""
 
     def __init__(self, *args, num_threads=10, **kwargs):
-        """Wrapper around the mattermostdriver Driver with some convenience functions
+        """Wrapper around the mattermostautodriver Driver with some convenience functions
         and attributes.
 
         Arguments:

--- a/mmpy_bot/driver.py
+++ b/mmpy_bot/driver.py
@@ -16,8 +16,8 @@ class Driver(mattermostautodriver.Driver):
     username: str = ""
 
     def __init__(self, *args, num_threads=10, **kwargs):
-        """Wrapper around the mattermostautodriver Driver with some convenience functions
-        and attributes.
+        """Wrapper around the mattermostautodriver Driver with some convenience
+        functions and attributes.
 
         Arguments:
         - num_threads: int, number of threads to use for the default worker threadpool.
@@ -78,7 +78,9 @@ class Driver(mattermostautodriver.Driver):
         return self.posts.create_post(post)
 
     def get_thread(self, post_id: str):
-        warnings.warn("get_thread is deprecated. Use get_post_thread instead", DeprecationWarning)
+        warnings.warn(
+            "get_thread is deprecated. Use get_post_thread instead", DeprecationWarning
+        )
         return self.get_post_thread(post_id)
 
     def get_post_thread(self, post_id: str):
@@ -163,9 +165,9 @@ class Driver(mattermostautodriver.Driver):
     ):
         # Private/direct messages are sent to a special channel that
         # includes the bot and the recipient
-        direct_id = self.channels.create_direct_channel(
-            [self.user_id, receiver_id]
-        )["id"]
+        direct_id = self.channels.create_direct_channel([self.user_id, receiver_id])[
+            "id"
+        ]
 
         return self.create_post(
             channel_id=direct_id,

--- a/mmpy_bot/driver.py
+++ b/mmpy_bot/driver.py
@@ -96,7 +96,7 @@ class Driver(mattermostdriver.Driver):
 
     def react_to(self, message: Message, emoji_name: str):
         """Adds an emoji reaction to the given message."""
-        return self.reactions.create_reaction(
+        return self.reactions.save_reaction(
             {
                 "user_id": self.user_id,
                 "post_id": message.id,

--- a/mmpy_bot/plugins/example.py
+++ b/mmpy_bot/plugins/example.py
@@ -85,7 +85,7 @@ class ExamplePlugin(Plugin):
     @listen_to("^!hello_webhook$", re.IGNORECASE, category="webhook")
     async def hello_webhook(self, message: Message):
         """A webhook that says hello."""
-        self.driver.webhooks.call_webhook(
+        self.driver.client.call_webhook(
             "eauegoqk4ibxigfybqrsfmt48r",
             options={
                 "username": "webhook_test",  # Requires the right webhook permissions

--- a/mmpy_bot/plugins/example.py
+++ b/mmpy_bot/plugins/example.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 
 import click
-import mattermostdriver
+import mattermostautodriver
 
 from mmpy_bot.function import listen_to
 from mmpy_bot.plugins.base import Plugin
@@ -65,7 +65,7 @@ class ExamplePlugin(Plugin):
         permissions."""
         try:
             self.driver.reply_to(message, "hello sender!", ephemeral=True)
-        except mattermostdriver.exceptions.NotEnoughPermissions:
+        except mattermostautodriver.exceptions.NotEnoughPermissions:
             self.driver.reply_to(
                 message, "I do not have permission to create ephemeral posts!"
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.7.4.post0
 click>=7.0
-mattermostautodriver>=1.1.0
+mattermostautodriver>=1.2.0
 schedule>=0.6.0
 Sphinx>=1.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.7.4.post0
 click>=7.0
-mattermostdriver>=7.3.2
+mattermostautodriver>=1.1.0
 schedule>=0.6.0
 Sphinx>=1.3.3

--- a/tests/integration_tests/test_direct_message_plugin.py
+++ b/tests/integration_tests/test_direct_message_plugin.py
@@ -41,7 +41,7 @@ class TestDirectPlugin:
         # which is implemented by mattermost as a channel
         driver.create_post(OFF_TOPIC_ID, trigger)
 
-        user_channels = driver.channels.get_channels_for_user(driver.user_id, TEAM_ID)
+        user_channels = driver.channels.get_channels_for_team_for_user(driver.user_id, TEAM_ID)
         channels = list(filter(bot_and_user_direct_channel, user_channels))
 
         # We need to wait for the reply to be processed by mattermost
@@ -51,7 +51,7 @@ class TestDirectPlugin:
         for _ in range(retries):
             if len(channels) != 1:
                 time.sleep(RESPONSE_TIMEOUT)
-                user_channels = driver.channels.get_channels_for_user(
+                user_channels = driver.channels.get_channels_for_team_for_user(
                     driver.user_id, TEAM_ID
                 )
                 channels = list(filter(bot_and_user_direct_channel, user_channels))

--- a/tests/integration_tests/test_direct_message_plugin.py
+++ b/tests/integration_tests/test_direct_message_plugin.py
@@ -41,7 +41,9 @@ class TestDirectPlugin:
         # which is implemented by mattermost as a channel
         driver.create_post(OFF_TOPIC_ID, trigger)
 
-        user_channels = driver.channels.get_channels_for_team_for_user(driver.user_id, TEAM_ID)
+        user_channels = driver.channels.get_channels_for_team_for_user(
+            driver.user_id, TEAM_ID
+        )
         channels = list(filter(bot_and_user_direct_channel, user_channels))
 
         # We need to wait for the reply to be processed by mattermost

--- a/tests/integration_tests/test_example_plugin.py
+++ b/tests/integration_tests/test_example_plugin.py
@@ -93,7 +93,7 @@ class TestExamplePlugin:
     def test_react(self, driver):
         post_id = driver.create_post(OFF_TOPIC_ID, "@main_bot hello_react")["id"]
         time.sleep(RESPONSE_TIMEOUT)
-        reactions = driver.reactions.get_reactions_of_post(post_id)
+        reactions = driver.reactions.get_reactions(post_id)
         assert len(reactions) == 1
         assert reactions[0]["emoji_name"] == "+1"
 

--- a/tests/integration_tests/test_example_plugin.py
+++ b/tests/integration_tests/test_example_plugin.py
@@ -33,7 +33,7 @@ class TestExamplePlugin:
 
         # For the direct message, we expect to have insufficient permissions, since
         # our name isn't admin
-        private_channel = driver.channels.create_direct_message_channel(
+        private_channel = driver.channels.create_direct_channel(
             [driver.user_id, MAIN_BOT_ID]
         )["id"]
         post = driver.create_post(private_channel, "admin")

--- a/tests/integration_tests/test_example_plugin.py
+++ b/tests/integration_tests/test_example_plugin.py
@@ -28,7 +28,7 @@ class TestExamplePlugin:
         # Since this is not a direct message, we expect no reply at all
         post_id = driver.create_post(OFF_TOPIC_ID, "@main_bot admin")["id"]
         time.sleep(RESPONSE_TIMEOUT)
-        thread_info = driver.get_thread(post_id)
+        thread_info = driver.get_post_thread(post_id)
         assert len(thread_info["order"]) == 1
 
         # For the direct message, we expect to have insufficient permissions, since

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -27,7 +27,7 @@ def expect_reply(driver: Driver, post: Dict, wait=RESPONSE_TIMEOUT, retries=1):
     reply = None
     for _ in range(retries + 1):
         time.sleep(wait)
-        thread_info = driver.get_thread(post["id"])
+        thread_info = driver.get_post_thread(post["id"])
         print(thread_info)
         reply_id = thread_info["order"][-1]
         if reply_id != post["id"]:


### PR DESCRIPTION
As discussed at https://github.com/Vaelor/python-mattermost-driver/pull/100 the latest release of `mattermostdriver` is missing several API endpoints. The fork [python-mattermost-autodriver](https://github.com/embl-bio-it/python-mattermost-autodriver) uses an approach that transforms Mattermost's OpenAPI documentation to Python code, ensuring all endpoints are readily available.

The current PR updates the core of mmpy_bot to use the new API driver. The core functionality is the same but as endpoints were automatically generated, some functions have different names. Unless I missed some, this PR should address all of them.