### PR TITLE
function: Match standalone call for click command pattern

### DIFF
--- a/mmpy_bot/function.py
+++ b/mmpy_bot/function.py
@@ -107,7 +107,7 @@ class MessageFunction(Function):
                 )
             with click.Context(
                 self.function,
-                info_name=self.matcher.pattern.strip("^").split(" (.*)?")[0],
+                info_name=self.matcher.pattern.strip("^").split("(?: |$)(.*)?")[0],
             ) as ctx:
                 # Get click help string and do some extra formatting
                 self.docstring += f"\n\n{self.function.get_help(ctx)}"
@@ -206,7 +206,7 @@ def listen_to(
             # Modify the regexp so that it won't try to match the individual arguments.
             # Click will take care of those. We also manually add the ^ if necessary,
             # so that the commands can't be inserted in the middle of a sentence.
-            reg = f"^{reg.strip('^')} (.*)?"  # noqa
+            reg = rf"^{reg.strip('^')}(?: |$)(.*)?"  # noqa
 
         pattern = re.compile(reg, regexp_flag)
         new_func = MessageFunction(

--- a/tests/unit_tests/plugin_manager_test.py
+++ b/tests/unit_tests/plugin_manager_test.py
@@ -67,7 +67,7 @@ msg_listeners = {
     re.compile("async_pattern"): expand_func_names(FakePlugin.my_async_function),
     re.compile("hi_custom"): expand_func_names(FakePlugin.hi_custom),
     # Click commands construct a regex pattern from the listen_to pattern
-    re.compile("^click_command (.*)?"): expand_func_names(FakePlugin.click_commmand),
+    re.compile("^click_command(?: |$)(.*)?"): expand_func_names(FakePlugin.click_commmand),
 }
 
 hook_listeners = {

--- a/tests/unit_tests/plugin_manager_test.py
+++ b/tests/unit_tests/plugin_manager_test.py
@@ -67,7 +67,9 @@ msg_listeners = {
     re.compile("async_pattern"): expand_func_names(FakePlugin.my_async_function),
     re.compile("hi_custom"): expand_func_names(FakePlugin.hi_custom),
     # Click commands construct a regex pattern from the listen_to pattern
-    re.compile("^click_command(?: |$)(.*)?"): expand_func_names(FakePlugin.click_commmand),
+    re.compile("^click_command(?: |$)(.*)?"): expand_func_names(
+        FakePlugin.click_commmand
+    ),
 }
 
 hook_listeners = {


### PR DESCRIPTION
Hi,
The click command can match massages like `command arg1 arg2`, but cannot match the call with no arguments like `command`.  
Thus a minor update on the regexp patterns is commited to resolve this issue.