### PR TITLE
Fix quote marks in publish workflow version title

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
-          title: v'${{ github.event.inputs.version }}''
+          title: "v${{ github.event.inputs.version }}"
           files: |
             LICENSE
             dist/*.whl


### PR DESCRIPTION
Old title created `v'2.1.3''` as title in the releases page