### PR TITLE
Fix incompatibilities with mattermostautodriver 1.3.0

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ Active Contributors
 * Jelmer Neeven <jelmer@neeven.tech>
 * Renato Alves <alves.rjc@gmail.com>
 * Thomas Tuffin <ttuffin@redhat.com>
+* Amin Aminian <a.aminian321@gmail.com>
 
 Past Contributors
 -----------------

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ bot = Bot(
     settings=Settings(
         MATTERMOST_URL = "http://chat.example.com",
         MATTERMOST_PORT = 443,
-        MATTERMOST_API_PATH = '/api/v4',
         BOT_TOKEN = "a69155mvlsobcnqpfdceqihaa",
         BOT_TEAM = "test",
         SSL_VERIFY = True,

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -51,7 +51,6 @@ look something like this:
             settings=Settings(
                 MATTERMOST_URL = "http://<mattermost_server_url>",
                 MATTERMOST_PORT = 443,
-                MATTERMOST_API_PATH = '/api/v4',
                 BOT_TOKEN = "<your_bot_token>",
                 BOT_TEAM = "<team_name>",
                 SSL_VERIFY = True,

--- a/mmpy_bot/settings.py
+++ b/mmpy_bot/settings.py
@@ -1,5 +1,6 @@
 import collections
 import os
+import warnings
 from dataclasses import dataclass, field, fields
 from typing import Optional, Sequence, Union, get_args, get_origin  # type: ignore
 
@@ -48,7 +49,7 @@ class Settings:
 
     MATTERMOST_URL: str = "https://chat.com"
     MATTERMOST_PORT: int = 443
-    MATTERMOST_API_PATH: str = "/api/v4"
+    MATTERMOST_API_PATH: str = ""
     BOT_TOKEN: str = "token"
     BOT_TEAM: str = "team_name"
     SSL_VERIFY: bool = True
@@ -76,6 +77,19 @@ class Settings:
             self.SCHEME, self.MATTERMOST_URL = self.MATTERMOST_URL.split("://")
         else:
             self.SCHEME = "https"
+
+        api_url = "/api/v4"
+
+        if self.MATTERMOST_API_PATH.endswith(api_url):
+            warnings.warn(
+                (
+                    f"MATTERMOST_API_PATH should no longer include {api_url} "
+                    "or be set unless you run mattermost in a subfolder "
+                    "(example.com/mattermost/)."
+                ),
+                DeprecationWarning,
+            )
+            self.MATTERMOST_API_PATH = self.MATTERMOST_API_PATH[: -len(api_url)]
 
     def _check_environment_variables(self):
         for f in fields(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.7.4.post0
 click>=7.0
-mattermostautodriver>=1.2.2
+mattermostautodriver~=1.3.0
 schedule>=0.6.0
 Sphinx>=1.3.3


### PR DESCRIPTION
Due to changes to mattermostautodriver the `MATTERMOST_API_PATH` argument should no longer contain `/api/v4` and instead should only be used when the mattermost server is running from a subfolder, for instance http://example.com/mattermost-server/

See #430 for additional context.