### PR TITLE
Pin current mmpy_bot to mattermostautodriver 1.2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.7.4.post0
 click>=7.0
-mattermostautodriver>=1.2.2
+mattermostautodriver~=1.2.2
 schedule>=0.6.0
 Sphinx>=1.3.3


### PR DESCRIPTION
Proposed change in https://github.com/attzonko/mmpy_bot/pull/431#issuecomment-1672099087 for interim release `mmpy_bot-2.1.4`.