### PR TITLE
Configurable log level

### DIFF
--- a/mmpy_bot/bot.py
+++ b/mmpy_bot/bot.py
@@ -80,7 +80,9 @@ class Bot:
             **{
                 "format": self.settings.LOG_FORMAT,
                 "datefmt": self.settings.LOG_DATE_FORMAT,
-                "level": logging.DEBUG if self.settings.DEBUG else logging.INFO,
+                "level": (
+                    logging.DEBUG if self.settings.DEBUG else self.settings.LOG_LEVEL
+                ),
                 "filename": self.settings.LOG_FILE,
                 "filemode": "w",
             }

--- a/mmpy_bot/settings.py
+++ b/mmpy_bot/settings.py
@@ -1,7 +1,7 @@
 import collections
+import logging
 import os
 import warnings
-import logging
 from dataclasses import dataclass, field, fields
 from typing import Optional, Sequence, Union, get_args, get_origin  # type: ignore
 

--- a/mmpy_bot/settings.py
+++ b/mmpy_bot/settings.py
@@ -1,6 +1,7 @@
 import collections
 import os
 import warnings
+import logging
 from dataclasses import dataclass, field, fields
 from typing import Optional, Sequence, Union, get_args, get_origin  # type: ignore
 
@@ -59,6 +60,7 @@ class Settings:
     DEBUG: bool = False
     # Respond to channel message "!help" (without @bot)
     RESPOND_CHANNEL_HELP: bool = False
+    LOG_LEVEL: int = logging.INFO
     LOG_FILE: Optional[str] = None
     LOG_FORMAT: str = "[%(asctime)s][%(name)s][%(levelname)s] %(message)s"
     LOG_DATE_FORMAT: str = "%m/%d/%Y %H:%M:%S"
@@ -90,6 +92,13 @@ class Settings:
                 DeprecationWarning,
             )
             self.MATTERMOST_API_PATH = self.MATTERMOST_API_PATH[: -len(api_url)]
+
+        if self.DEBUG:
+            warnings.warn(
+                "DEBUG has been deprecated and will be removed in a future release. "
+                "Set LOG_LEVEL to logging.DEBUG to increase verbosity.",
+                DeprecationWarning,
+            )
 
     def _check_environment_variables(self):
         for f in fields(self):

--- a/tests/unit_tests/bot_test.py
+++ b/tests/unit_tests/bot_test.py
@@ -1,7 +1,7 @@
+import logging
 from unittest import mock
 
 import pytest
-import logging
 
 from mmpy_bot import Bot, ExamplePlugin, Settings
 from mmpy_bot.plugins import PluginManager

--- a/tests/unit_tests/bot_test.py
+++ b/tests/unit_tests/bot_test.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+import logging
 
 from mmpy_bot import Bot, ExamplePlugin, Settings
 from mmpy_bot.plugins import PluginManager
@@ -12,7 +13,7 @@ from ..integration_tests.utils import TestPlugin
 def bot():
     # Patch login to avoid sending requests to the internet
     with mock.patch("mmpy_bot.driver.Driver.login") as login:
-        bot = Bot(plugins=[ExamplePlugin()], settings=Settings(DEBUG=True))
+        bot = Bot(plugins=[ExamplePlugin()], settings=Settings(LOG_LEVEL=logging.DEBUG))
         login.assert_called_once()
         yield bot
         bot.stop()  # if the bot was started, stop it


### PR DESCRIPTION
Backwards-compatible, and only takes precedence over the fallback value.

Closes #498.

This code is untested but also a pretty minor change. I'm happy to modify it.