### PR TITLE
Increase the poll interval to reduce CPU consumption

### DIFF
--- a/mmpy_bot/event_handler.py
+++ b/mmpy_bot/event_handler.py
@@ -48,8 +48,7 @@ class EventHandler:
                 event = webhook_queue.get_nowait()
                 await self._handle_webhook(event)
             except queue.Empty:
-                pass
-            await asyncio.sleep(0.0001)
+                await asyncio.sleep(0.5)
 
     async def _handle_event(self, data):
         post = json.loads(data)

--- a/mmpy_bot/threadpool.py
+++ b/mmpy_bot/threadpool.py
@@ -93,7 +93,7 @@ class ThreadPool(object):
             await webhook_server.start()
             while self.alive:
                 # We just use this to keep the loop running in a non-blocking way
-                await asyncio.sleep(0.001)
+                await asyncio.sleep(1)
             await webhook_server.stop()
             log.info("Webhook server thread stopped.")
 

--- a/mmpy_bot/webhook_server.py
+++ b/mmpy_bot/webhook_server.py
@@ -81,8 +81,7 @@ class WebHookServer:
                     # If this handler already received a response, we can skip this.
                     pass
             except Empty:
-                pass
-            await asyncio.sleep(0.0001)
+                await asyncio.sleep(0.5)
 
     @handle_json_error
     async def process_webhook(self, request: web.Request):

--- a/tests/unit_tests/webhook_server_test.py
+++ b/tests/unit_tests/webhook_server_test.py
@@ -24,7 +24,7 @@ class TestWebHookServer:
         server = WebHookServer(port=3281, url=Settings().WEBHOOK_HOST_URL)
         threadpool.start_webhook_server_thread(server)
         threadpool.start()
-        time.sleep(0.5)
+        time.sleep(1)
         assert server.running
 
         asyncio.set_event_loop(asyncio.new_event_loop())
@@ -48,13 +48,13 @@ class TestWebHookServer:
         # We have no futures waiting for request id 'nonexistent', so nothing should
         # happen.
         server.response_queue.put(("nonexistent", None))
-        time.sleep(0.1)
+        time.sleep(1)
         assert not server.response_handlers["test"].done()
 
         # If a response comes in for request id 'test', it should be removed from the
         # response handlers dict.
         server.response_queue.put(("test", None))
-        time.sleep(0.1)
+        time.sleep(1)
         assert "test" not in server.response_handlers
 
     @pytest.mark.skip("Called from test_start since we can't parallellize this.")
@@ -86,7 +86,7 @@ class TestWebHookServer:
 
         # Since there is no MessageHandler, we have to signal the server ourselves
         server.response_queue.put((event.request_id, NoResponse))
-        time.sleep(0.1)
+        time.sleep(1)
         # Upon receiving the NoResponse, the server should have emptied the response
         # queue and handlers.
         assert server.response_queue.empty()


### PR DESCRIPTION
The CPU usage is high when Webhook server is enabled, and I found it caused by the `asyncio.sleep` with too short interval.

If it's hard to fix the "thread pool with asyncio" issue, I want to increase the poll interval when the queue is empty.