### PR TITLE
Permit per-plugin/per-listener reply-to-self

### DIFF
--- a/mmpy_bot/event_handler.py
+++ b/mmpy_bot/event_handler.py
@@ -19,13 +19,11 @@ class EventHandler(object):
         driver: Driver,
         settings: Settings,
         plugin_manager: PluginManager,
-        ignore_own_messages=True,
     ):
         """The EventHandler class takes care of the connection to mattermost and calling
         the appropriate response function to each event."""
         self.driver = driver
         self.settings = settings
-        self.ignore_own_messages = ignore_own_messages
         self.plugin_manager = plugin_manager
 
         self._name_matcher = re.compile(rf"^@?{self.driver.username}[:,]?\s?")
@@ -41,7 +39,7 @@ class EventHandler(object):
             if message.sender_name.lower()
             in (name.lower() for name in self.settings.IGNORE_USERS)
             else False
-        ) or (self.ignore_own_messages and message.sender_name == self.driver.username)
+        ) or (self.settings.IGNORE_OWN_MESSAGES and message.sender_name == self.driver.username)
 
     async def _check_queue_loop(self, webhook_queue: queue.Queue):
         log.info("EventHandlerWebHook queue listener started.")

--- a/mmpy_bot/function.py
+++ b/mmpy_bot/function.py
@@ -73,6 +73,7 @@ class MessageFunction(Function):
         *args,
         direct_only: bool = False,
         needs_mention: bool = False,
+        ignore_own_messages: bool = True,
         silence_fail_msg: bool = False,
         allowed_users: Optional[Sequence[str]] = None,
         allowed_channels: Optional[Sequence[str]] = None,
@@ -83,6 +84,7 @@ class MessageFunction(Function):
         self.is_click_function = isinstance(self.function, click.Command)
         self.direct_only = direct_only
         self.needs_mention = needs_mention
+        self.ignore_own_messages = ignore_own_messages
         self.silence_fail_msg = silence_fail_msg
 
         if allowed_users is None:
@@ -132,6 +134,9 @@ class MessageFunction(Function):
         if self.direct_only and not message.is_direct_message:
             return return_value
 
+        if self.ignore_own_messages and (message.sender_name == self.plugin.driver.username):
+            return return_value
+
         if self.needs_mention and not (
             message.is_direct_message or self.plugin.driver.user_id in message.mentions
         ):
@@ -179,6 +184,7 @@ def listen_to(
     *,
     direct_only=False,
     needs_mention=False,
+    ignore_own_messages=True,
     allowed_users=None,
     allowed_channels=None,
     silence_fail_msg=False,
@@ -214,6 +220,7 @@ def listen_to(
             matcher=pattern,
             direct_only=direct_only,
             needs_mention=needs_mention,
+            ignore_own_messages=ignore_own_messages,
             allowed_users=allowed_users,
             allowed_channels=allowed_channels,
             silence_fail_msg=silence_fail_msg,

--- a/mmpy_bot/plugins/example.py
+++ b/mmpy_bot/plugins/example.py
@@ -171,3 +171,8 @@ class ExamplePlugin(Plugin):
         self.driver.reply_to(message, f"Okay, I will be waiting {seconds} seconds.")
         await asyncio.sleep(int(seconds))
         self.driver.reply_to(message, "Done!")
+
+    @listen_to("^@thisuser$", re.IGNORECASE, ignore_own_messages=False)
+    def custom_ping_replytoself(self, message: Message):
+        """Demonstration of ignore_own_messages, requires global settings IGNORE_OWN_MESSAGES = False"""
+        self.driver.reply_to(message, f"Hello @{message.sender_name}")

--- a/mmpy_bot/settings.py
+++ b/mmpy_bot/settings.py
@@ -65,6 +65,7 @@ class Settings:
     LOG_FORMAT: str = "[%(asctime)s][%(name)s][%(levelname)s] %(message)s"
     LOG_DATE_FORMAT: str = "%m/%d/%Y %H:%M:%S"
 
+    IGNORE_OWN_MESSAGES: bool = True
     IGNORE_USERS: Sequence[str] = field(default_factory=list)
     # How often to check whether any scheduled jobs need to be run, default every second
     SCHEDULER_PERIOD: float = 1.0


### PR DESCRIPTION
This PR implements a per-plugin reply-to-self functionality, allowing the bot to, for selected `listen_to` statements, reply to its own previous messages. For example, this would allow the bot to send a reply like "Hey @sender do the thing" to a trigger, and then handle its own "@sender" listener for that message.

First, we turn the `EventHandler` `ignore_own_messages` into a global `mmpy_bot` setting, which defaults to `True` to preserve the existing behaviour; the bot user must turn this off to use this new feature.

Second, we add a handler within the `MessageFunction` that duplicates the functionality in `EventHandler`; this ensures that the existing behaviour continues to be preserved, even if the global setting is `False`.

Finally, we add another kwarg to the `listen_to` decorator to permit passing an `ignore_own_message=False` option, which would then allow that particular listener to ignore the previous conditions and reply to itself.

Information about this functionality, including a warning about loops, has been added to the documentation on Plugins at the bottom of the page, to ensure users become aware of this new feature and what needs to be done to activate it.