### PR TITLE
Fixed return of parent_id in Message wrapper

### DIFF
--- a/mmpy_bot/wrappers.py
+++ b/mmpy_bot/wrappers.py
@@ -52,7 +52,7 @@ class Message(EventWrapper):
 
     @cached_property
     def parent_id(self):
-        return self.body["data"]["post"]["parent_id"]
+        return self.body["data"]["post"].get("parent_id", "").strip()
 
     @cached_property
     def reply_id(self):


### PR DESCRIPTION
Better return of parameter "parent_id" if it is not exist, before this fix the attribute returns an error in its body.

Before: `'message.parent_id = KeyError: 'parent_id'`
After: `'message.parent_id = ''`