### PR TITLE
snapshottest: 0.6.0 > 1.0.0a1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,4 +6,4 @@ flake8==7.1.0
 pytest==8.2.2
 pytest-xdist==3.6.1
 pytype==2024.4.11
-snapshottest==0.6.0
+snapshottest==1.0.0a1

--- a/tests/unit_tests/bot_test.py
+++ b/tests/unit_tests/bot_test.py
@@ -27,9 +27,10 @@ class TestBot:
         for plugin in plugins:
             plugin.initialize = mock.MagicMock()
 
+        settings = Settings(MATTERMOST_URL="test_url.org", BOT_TOKEN="random_token")
         # Create a bot and verify that it gets initialized correctly
         bot = Bot(
-            settings=Settings(MATTERMOST_URL="test_url.org", BOT_TOKEN="random_token"),
+            settings=settings,
             plugins=plugins,
         )
         assert bot.driver.options["url"] == "test_url.org"
@@ -40,7 +41,9 @@ class TestBot:
 
         # Verify that all of the passed plugins were initialized
         for plugin in plugins:
-            assert plugin.initialize.called_once_with(bot.driver)
+            plugin.initialize.assert_called_once_with(
+                bot.driver, bot.plugin_manager, settings
+            )
 
     @mock.patch.multiple("mmpy_bot.Plugin", on_start=mock.DEFAULT, on_stop=mock.DEFAULT)
     def test_run(self, bot, **mocks):

--- a/tests/unit_tests/plugin_manager_test.py
+++ b/tests/unit_tests/plugin_manager_test.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from unittest import mock
 
 import click
@@ -145,13 +146,14 @@ class TestPluginManager:
 
         for hlp in self.plugin_manager.get_help():
             assert hlp.location == "FakePlugin"
-            assert (
-                hlp.function.plugin.__doc__
-                == """Hello FakePlugin.
+            if sys.version_info >= (3, 13):
+                test_doc = "Hello FakePlugin.\n\nThis is a plugin level docstring\n"
+            else:
+                test_doc = """Hello FakePlugin.
 
     This is a plugin level docstring
     """
-            )
+            assert hlp.function.plugin.__doc__ == test_doc
             assert hlp.is_click == hlp.function.is_click_function
             assert hlp.docfull.startswith(hlp.function.__doc__)
 


### PR DESCRIPTION
0.6.0 uses `imp` which has been deprecated in Py 3.12 and removed in 3.13. Newest snapshottest fixes the deprecation error