### PR TITLE
Update Python versions in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11']
 
     steps:
       - name: Cancel Outdated Runs
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Reduced Python versions in unit and integration tests to 3.10 and 3.11.

With 3.9 EOL coming and not having time to fix the issues with 3.12 and 3.13 scoping down to 3.10 and 3.11.

If anyone has time to get 3.12. and 3.13 working submit a PR