### PR TITLE
ci: upgrade Python to 3.11 and update pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Configure Python 3.10
+      - name: Configure Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Use Pip cache if available
         uses: actions/cache@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-merge-conflict
   - repo: https://github.com/pycqa/isort
     # Formants, sorts and reorganizes imports
-    rev: 7.0.0
+    rev: 8.0.1
     hooks:
       - id: isort
         args:
@@ -22,7 +22,7 @@ repos:
           - "--filter-files"
   - repo: https://github.com/psf/black
     # Code style formatting
-    rev: 25.9.0
+    rev: 25.12.1
     hooks:
       - id: black
         exclude: (.*/)*snapshots/
@@ -49,7 +49,7 @@ repos:
           - "auto"
   - repo: https://github.com/myint/docformatter
     # Formats docstrings following PEP 257
-    rev: v1.7.7
+    rev: v1.8.1
     hooks:
       - id: docformatter
         args:


### PR DESCRIPTION
- Update Python version from 3.10 to 3.11 in pre-commit autoupdate workflow
- Upgrade docformatter from v1.7.7 to v1.8.1 (requires Python 3.11+)
- Upgrade black from 25.9.0 to 25.12.1
- Upgrade isort from 7.0.0 to 8.0.1 (stable release)

This resolves the NameError: name 'tomllib' is not defined issue that occurred with docformatter v1.7.8+ on Python 3.10.